### PR TITLE
Make location of viminfo configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,9 @@ $_FASD_FUZZY
 Level of "fuzziness" when doing fuzzy matching. More precisely, the number of
 characters that can be skipped to generate a match. Set to empty or 0 to
 disable fuzzy matching. Default value is 2.
+
+$_FASD_VIMINFO
+Location of .viminfo file if not located in "$HOME/.viminfo"
 ```
 
 # Debugging

--- a/fasd
+++ b/fasd
@@ -49,6 +49,7 @@ fasd() {
           [ -z "$_FASD_MAX" ] && _FASD_MAX=2000
           [ -z "$_FASD_BACKENDS" ] && _FASD_BACKENDS=native
           [ -z "$_FASD_FUZZY" ] && _FASD_FUZZY=2
+          [ -z "$_FASD_VIMINFO" ] && _FASD_VIMINFO="$HOME/.viminfo"
 
           if [ -z "$_FASD_AWK" ]; then
             # awk preferences
@@ -470,7 +471,7 @@ $(fasd --backend $each)"
     case $2 in
       native) cat "$_FASD_DATA";;
       viminfo)
-        < "$HOME/.viminfo" sed -n '/^>/{s@~@'"$HOME"'@
+        < "$_FASD_VIMINFO" sed -n '/^>/{s@~@'"$HOME"'@
           s/^..//
           p
           }' | $_FASD_AWK -v t="$(date +%s)" '{

--- a/fasd.1
+++ b/fasd.1
@@ -236,6 +236,9 @@ $_FASD_FUZZY
 Level\ of\ "fuzziness"\ when\ doing\ fuzzy\ matching.\ More\ precisely,\ the\ number\ of
 characters\ that\ can\ be\ skipped\ to\ generate\ a\ match.\ Set\ to\ empty\ or\ 0\ to
 disable\ fuzzy\ matching.\ Default\ value\ is\ 2.
+
+$_FASD_VIMINFO
+Location\ of\ .viminfo\ file\ if\ not\ located\ in\ "$HOME/.viminfo"
 \f[]
 .fi
 .SH DEBUGGING

--- a/fasd.1.md
+++ b/fasd.1.md
@@ -199,6 +199,9 @@ they are present. Below are some variables you can set:
     characters that can be skipped to generate a match. Set to empty or 0 to
     disable fuzzy matching. Default value is 2.
 
+    $_FASD_VIMINFO
+    Location of .viminfo file if not located in "$HOME/.viminfo"
+
 # DEBUGGING
 
 Fasd is hosted on GitHub: https://github.com/clvv/fasd


### PR DESCRIPTION
This add '$_FASD_VIMINFO' which can be set in fasdrc or defaults to $HOME/.viminfo
