### PR TITLE
Provide means for overriding interactive mode logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,10 @@ $_FASD_RECENTLY_USED_XBEL
 Path to XDG recently-used.xbel file for recently-used backend, defaults to
 "$HOME/.local/share/recently-used.xbel"
 
+$_FASD_INTERACTIVE_FUNC
+Interactive function name used for processing lists in interactive mode,
+defaults to "_fasd_interactive_func".
+
 ```
 
 # Debugging

--- a/fasd
+++ b/fasd
@@ -54,6 +54,8 @@ fasd() {
           [ -z "$_FASD_VIMINFO" ] && _FASD_VIMINFO="$HOME/.viminfo"
           [ -z "$_FASD_RECENTLY_USED_XBEL" ] && \
             _FASD_RECENTLY_USED_XBEL="$HOME/.local/share/recently-used.xbel"
+          [ -z "$_FASD_INTERACTIVE_FUNC" ] && \
+            _FASD_INTERACTIVE_FUNC=_fasd_interactive_func
 
           if [ -z "$_FASD_AWK" ]; then
             # awk preferences
@@ -582,13 +584,7 @@ fasd [-A|-D] [paths ...]
       res="$(printf %s\\n "$res" | sort -n${R} | \
         sed -n "$_fasd_i"'s/^[^ ]*[ ]*//p')"
     elif [ "$interactive" ] || [ "$exec" -a -z "$fnd$lst$show" -a -t 1 ]; then
-      if [ "$(printf %s "$res" | sed -n '$=')" -gt 1 ]; then
-        res="$(printf %s\\n "$res" | sort -n${R})"
-        printf %s\\n "$res" | sed = | sed 'N;s/\n/	/' | sort -nr >&2
-        printf "> " >&2
-        local i; read i; [ 0 -lt "${i:-0}" ] 2>> "$_FASD_SINK" || return 1
-      fi
-      res="$(printf %s\\n "$res" | sed -n "${i:-1}"'s/^[^ ]*[ ]*//p')"
+      res="$("$_FASD_INTERACTIVE_FUNC" "$res" "$R")"
     elif [ "$lst" ]; then
       [ "$res" ] && printf %s\\n "$res" | sort -n${r} | sed 's/^[^ ]*[ ]*//'
       return
@@ -608,6 +604,18 @@ fasd [-A|-D] [paths ...]
     fi
     ;;
   esac
+}
+
+_fasd_interactive_func() {
+  local res="$1"
+  local R="$2"
+  if [ "$(printf %s "$res" | sed -n '$=')" -gt 1 ]; then
+    res="$(printf %s\\n "$res" | sort -n${R})"
+    printf %s\\n "$res" | sed = | sed 'N;s/\n/  /' | sort -nr >&2
+    printf "> " >&2
+    local i; read i; [ 0 -lt "${i:-0}" ] 2>> "$_FASD_SINK" || return 1
+  fi
+  printf %s\\n "$res" | sed -n "${i:-1}"'s/^[^ ]*[ ]*//p'
 }
 
 fasd --init env

--- a/fasd.1.md
+++ b/fasd.1.md
@@ -231,6 +231,10 @@ they are present. Below are some variables you can set:
     Path to XDG recently-used.xbel file for recently-used backend, defaults to
     "$HOME/.local/share/recently-used.xbel"
 
+    $_FASD_INTERACTIVE_FUNC
+    Interactive function name used for processing lists in interactive mode,
+    defaults to "_fasd_interactive_func".
+
 # DEBUGGING
 
 Fasd is hosted on GitHub: https://github.com/clvv/fasd


### PR DESCRIPTION
The builtin interactive function implemented in fasd leaves much to be desired. This PR exposes a way to override the default implementation. I use https://github.com/mooz/percol for example in this manner:

``` bash
__user_fasd_interactive_func() {
    local selector="percol --auto-match --auto-fail"
    printf %s\\n "$1" | sed 's/^[^ ]*[ ]*//' | $selector
}
_FASD_INTERACTIVE_FUNC=__user_fasd_interactive_func
```