### PR TITLE
Word splitting issues resolved

### DIFF
--- a/fasd
+++ b/fasd
@@ -115,7 +115,7 @@ EOS
       zsh-hook) cat <<EOS
 # add zsh hook
 _fasd_preexec() {
-  { eval "fasd --proc \$(fasd --sanitize \$1)"; } >> "$_FASD_SINK" 2>&1
+  { eval "fasd --proc \$(fasd --sanitize \"\$1\")"; } >> "$_FASD_SINK" 2>&1
 }
 autoload -Uz add-zsh-hook
 add-zsh-hook preexec _fasd_preexec


### PR DESCRIPTION
Example of the issue on zsh with autocd turned on:

    ~/directory % cat <<!
    subdir1
    subdir2
    subdir3
    !
    [the output of cat]
    ~/directory/subdir1 %

The cwd has changed due to the heredoc lines being incorrectly split.

Another, much more threatening example:

    ~/ % ls
    [the directory is empty]
    ~/ % cat <<!
    touch newfile
    !
    [the output of cat]
    ~/ % ls
    newfile

It actually may lead to unintentional code execution.