### PR TITLE
Add an option (deactivated by default) to resolve symlinks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,10 @@ disable fuzzy matching. Default value is 2.
 $_FASD_VIMINFO
 Path to .viminfo file for viminfo backend, defaults to "$HOME/.viminfo"
 
+$_FASD_RESOLVE_SYMLINKS
+Set this option to 1 if you want fasd to resolve symbolic links. This is useful
+to prevent duplicates in the entry list. Defaults to 0.
+
 $_FASD_RECENTLY_USED_XBEL
 Path to XDG recently-used.xbel file for recently-used backend, defaults to
 "$HOME/.local/share/recently-used.xbel"

--- a/fasd
+++ b/fasd
@@ -52,6 +52,7 @@ fasd() {
           [ -z "$_FASD_BACKENDS" ] && _FASD_BACKENDS=native
           [ -z "$_FASD_FUZZY" ] && _FASD_FUZZY=2
           [ -z "$_FASD_VIMINFO" ] && _FASD_VIMINFO="$HOME/.viminfo"
+          [ -z "$_FASD_RESOLVE_SYMLINKS" ] && _FASD_RESOLVE_SYMLINKS=0
           [ -z "$_FASD_RECENTLY_USED_XBEL" ] && \
             _FASD_RECENTLY_USED_XBEL="$HOME/.local/share/recently-used.xbel"
 
@@ -328,10 +329,13 @@ EOS
       s@/\.\.$@/../@;s@/\(\./\)\{1,\}@/@g;:0
       s@[^/][^/]*//*\.\./@/@;t 0
       s@^/*\.\./@/@;s@//*@/@g;s@/\.\{0,1\}$@@;s@^$@/@' 2>> "$_FASD_SINK" \
+      | ( [ $_FASD_RESOLVE_SYMLINKS = 1 ] && xargs -I {} readlink -f {} || cat ) \
       | tr '\n' '|')"
 
     # add current pwd if the option is set
-    [ "$_FASD_TRACK_PWD" = "1" -a "$PWD" != "$HOME" ] && paths="$paths|$PWD"
+    local pwd="$PWD"
+    [ $_FASD_RESOLVE_SYMLINKS = 1 ] && pwd="$(readlink -f "$pwd")"
+    [ "$_FASD_TRACK_PWD" = 1 -a "$PWD" != "$HOME" ] && paths="$paths|$pwd"
 
     [ -z "${paths##\|}" ] && return # stop if we have nothing to add
 


### PR DESCRIPTION
By setting `$_FASD_RESOLVE_SYMLINKS` to 1, fasd will resolve symbolic links before storing paths in the entry list. This is useful when one is used to access the same directory both with a symbolic link and with the real (absolute) path, but wants only one entry for this directory in the list.

This option is set to 0 by default in order not to break retro-compatibility.

I am not familiar with shell scripting so any feedback is appreciated.