### PR TITLE
Add fasd.plugin.zsh to be loaded by antigen.

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ There are also three zle widgets: `fasd-complete`, `fasd-complete-f`,
 `fasd-complete-d`. You can bind them to keybindings you like:
 
 ```sh
-bindkey '^X^A' fasd-complete    # C-x C-a to do fasd-complete (fils and directories)
+bindkey '^X^A' fasd-complete    # C-x C-a to do fasd-complete (files and directories)
 bindkey '^X^F' fasd-complete-f  # C-x C-f to do fasd-complete-f (only files)
 bindkey '^X^D' fasd-complete-d  # C-x C-d to do fasd-complete-d (only directories)
 ```

--- a/fasd
+++ b/fasd
@@ -209,7 +209,7 @@ EOS
         ;;
 
       zsh-ccomp-install) cat <<EOS
-# enbale command mode completion
+# enable command mode completion
 compctl -U -K _fasd_zsh_cmd_complete -V fasd -x 'C[-1,-*e],s[-]n[1,e]' -c - \\
   'c[-1,-A][-1,-D]' -f -- fasd fasd_cd
 

--- a/fasd.1
+++ b/fasd.1
@@ -200,7 +200,7 @@ You can bind them to keybindings you like:
 .IP
 .nf
 \f[C]
-bindkey\ \[aq]^X^A\[aq]\ fasd\-complete\ \ \ \ #\ C\-x\ C\-a\ to\ do\ fasd\-complete\ (fils\ and\ directories)
+bindkey\ \[aq]^X^A\[aq]\ fasd\-complete\ \ \ \ #\ C\-x\ C\-a\ to\ do\ fasd\-complete\ (files\ and\ directories)
 bindkey\ \[aq]^X^F\[aq]\ fasd\-complete\-f\ \ #\ C\-x\ C\-f\ to\ do\ fasd\-complete\-f\ (only\ files)
 bindkey\ \[aq]^X^D\[aq]\ fasd\-complete\-d\ \ #\ C\-x\ C\-d\ to\ do\ fasd\-complete\-d\ (only\ directories)
 \f[]

--- a/fasd.1.md
+++ b/fasd.1.md
@@ -164,7 +164,7 @@ or ",,d" (directories). Examples:
 There are also three zle widgets: "fasd-complete", "fasd-complete-f",
 "fasd-complete-d". You can bind them to keybindings you like:
 
-    bindkey '^X^A' fasd-complete    # C-x C-a to do fasd-complete (fils and directories)
+    bindkey '^X^A' fasd-complete    # C-x C-a to do fasd-complete (files and directories)
     bindkey '^X^F' fasd-complete-f  # C-x C-f to do fasd-complete-f (only files)
     bindkey '^X^D' fasd-complete-d  # C-x C-d to do fasd-complete-d (only directories)
 

--- a/fasd.plugin.zsh
+++ b/fasd.plugin.zsh
@@ -1,0 +1,2 @@
+PATH=$PATH:$(dirname $0)
+eval "$(fasd --init auto)"


### PR DESCRIPTION
Antigen is a plugin manager for zsh, it clones plugin repo, looks for a
*.plugin.zsh file in plugin directy and sources it. After adding fasd.plugin.zsh
file, fasd can be simply installed by adding "antigen bundle clvv/fasd" to
.zshrc.
[antigen](https://github.com/zsh-users/antigen#notes-on-writing-plugins)
