### PR TITLE
Make --init auto evaluate to raw code

### DIFF
--- a/fasd
+++ b/fasd
@@ -64,18 +64,16 @@ fasd() {
         } >> "${_FASD_SINK:-/dev/null}" 2>&1
         ;;
 
-      auto) cat <<EOS
-{ if [ "\$ZSH_VERSION" ] && compctl; then # zsh
-    eval "\$(fasd --init posix-alias zsh-hook zsh-ccomp zsh-ccomp-install \\
-      zsh-wcomp zsh-wcomp-install)"
-  elif [ "\$BASH_VERSION" ] && complete; then # bash
-    eval "\$(fasd --init posix-alias bash-hook bash-ccomp bash-ccomp-install)"
-  else # posix shell
-    eval "\$(fasd --init posix-alias posix-hook)"
-  fi
-} >> "$_FASD_SINK" 2>&1
-
-EOS
+      auto) 
+        { if [ "\$ZSH_VERSION" ] && compctl > /dev/null; then # zsh
+            fasd --init posix-alias zsh-hook zsh-ccomp zsh-ccomp-install \\
+              zsh-wcomp zsh-wcomp-install
+          elif [ "\$BASH_VERSION" ] && complete > /dev/null; then # bash
+            fasd --init posix-alias bash-hook bash-ccomp bash-ccomp-install
+          else # posix shell
+            fasd --init posix-alias posix-hook
+          fi
+        } 2>> "$_FASD_SINK" 
         ;;
 
       posix-alias) cat <<EOS


### PR DESCRIPTION
Instead of evaluating to a "switch" statement, make `--init auto` evaluate
to the designated code for the current `$SHELL`. This improoves the
cache using

````shell
fasd_cache="$HOME/.fasd/fasd.$(basename $SHELL)"
if [ "$(command -v fasd)" -nt "$fasd_cache" -o ! -s "$fasd_cache" ]; then
  fasd --init auto poisx-alias >| "$fasd_cache"
fi
source $fasd_cache
unset fasd_cache
````

Also removes some redundant (?) messages about completion in `$_FASD_SINK`