### PR TITLE
Fix issue 15 better

### DIFF
--- a/fasd
+++ b/fasd
@@ -419,7 +419,7 @@ $(fasd --backend $each)"
     if [ "$fnd" ]; then # dafault matching
       local bre="$(printf %s\\n "$fnd" | sed 's/\([*\.\\\[]\)/\\\1/g
         s@ @[^|]*@g;s/\$$/|/')"
-      bre='^[^|]*'"$bre"'[^|/]*|'
+      bre='^[^|]*'"$bre"'[^|]*|'
       local _ret="$(printf %s\\n "$_fasd_data" | grep "$bre")"
       [ "$_ret" ] && _ret="$(printf %s\\n "$_ret" | while read -r line; do
         [ -${typ:-e} "${line%%\|*}" ] && printf %s\\n "$line"
@@ -438,7 +438,7 @@ $(fasd --backend $each)"
             sed 's/\([*\.\\\[]\)/\\\1/g;s/\$$/|/
               s@\(\\\{0,1\}[^ ]\)@\1[^|/]\\{0,'"$_FASD_FUZZY"'\\}@g
               s@ @[^|]*@g')"
-          fuzzy_bre='^[^|]*'"$fuzzy_bre"'[^|/]*|'
+          fuzzy_bre='^[^|]*'"$fuzzy_bre"'[^|]*|'
           _ret="$(printf %s\\n "$_fasd_data" | grep -i "$fuzzy_bre")"
           [ "$_ret" ] && _ret="$(printf %s\\n "$_ret" | while read -r line; do
             [ -${typ:-e} "${line%%\|*}" ] && printf %s\\n "$line"


### PR DESCRIPTION
[Note: This pull request got lost, so I rebased it and am resubmitting it.]

I think this fixes Issue 15 better than the issue-15 branch, because that branch seems to cause the previous mode to fail (i.e. if the query is the last element of the path, it returns no results).  With this patch, the following works:

$ cd ~/.mozilla/firefox/foo.bar
$ cd
$ fasd -d foo
1 ~/.mozilla/firefox/foo.bar
$ fasd -d bar
1 ~/.mozilla/firefox/foo.bar
$ fasd -d firefox
1 ~/.mozilla/firefox/foo.bar
$ fasd -d f f b
1 ~/.mozilla/firefox/foo.bar