### PR TITLE
fasd_cd: return 1 in case no dir was found

### DIFF
--- a/fasd
+++ b/fasd
@@ -91,7 +91,7 @@ fasd_cd() {
     fasd "\$@"
   else
     local _fasd_ret="\$(fasd -e 'printf %s' "\$@")"
-    [ -z "\$_fasd_ret" ] && return
+    [ -z "\$_fasd_ret" ] && return 1
     [ -d "\$_fasd_ret" ] && cd "\$_fasd_ret" || printf %s\\n "\$_fasd_ret"
   fi
 }


### PR DESCRIPTION
`fasd_cd doesnotexist` should return non-zero.
