### PR TITLE
Cygwin bash speedups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,13 @@ all: fasd.1
 
 uninstall:
 	rm -f ${DESTDIR}${BINDIR}/fasd
+	rm -f ${DESTDIR}${BINDIR}/fasd.bash
 	rm -f ${DESTDIR}${MANDIR}/man1/fasd.1
 
 install:
 	${INSTALLDIR} ${DESTDIR}${BINDIR}
 	${INSTALLBIN} fasd ${DESTDIR}${BINDIR}
+	${INSTALLBIN} fasd.bash ${DESTDIR}${BINDIR}
 	${INSTALLDIR} ${DESTDIR}${MANDIR}/man1
 	${INSTALLMAN} fasd.1 ${DESTDIR}${MANDIR}/man1
 

--- a/fasd
+++ b/fasd
@@ -330,14 +330,24 @@ EOS
     # find all valid path arguments, convert them to simplest absolute form
     local paths=""
     while [ "$1" ]; do
-        [ -e "$1" ] && paths+="$1"$'\n'; shift
+      [ ! -e "$1" ] && { shift; continue; }
+      p=$1
+      [[ "$p" =~ ^/ ]] || p="$PWD"/$p                  # make paths absolute
+      while [[ "$p" =~ (.*)/\./(.*) ]]; do             # clean up "./"
+        p=${BASH_REMATCH[1]}/${BASH_REMATCH[2]}
+      done
+      [[ "$p" =~ /\.\.$ ]] && p+=/                     # clean up final ".."
+      while [[ "$p" =~ (.*)[^/]+[/]+\.\./(.*) ]]; do   # clean up "../"
+        p=${BASH_REMATCH[1]}/${BASH_REMATCH[2]}
+      done
+      [[ "$p" =~ ^[/]?\.\.(/.*) ]] && p=${BASH_REMATCH[1]} # clean initial /../
+      while [[ "$p" =~ (.*)//(.*) ]]; do               # delete redundant /s
+        p=${BASH_REMATCH[1]}/${BASH_REMATCH[2]}
+      done
+      [[ "$p" =~ (.*)/[.]?$ ]] && p=${BASH_REMATCH[1]} # delete final / or /.
+      paths+=$p"|"
+      shift
     done
-    paths="$(sed '/^[^/]/s@^@'"$PWD"'/@
-      s@/\.\.$@/../@;s@/\(\./\)\{1,\}@/@g;:0
-      s@[^/][^/]*//*\.\./@/@;t 0
-      s@^/*\.\./@/@;s@//*@/@g;s@/\.\{0,1\}$@@;s@^$@/@' \
-          2>> "$_FASD_SINK" <<< "$paths")"
-    paths=${paths//$'\n'/|}
 
     # add current pwd if the option is set
     [ "$_FASD_TRACK_PWD" = "1" -a "$PWD" != "$HOME" ] && paths="$paths|$PWD"

--- a/fasd
+++ b/fasd
@@ -561,9 +561,12 @@ $(fasd --backend $each)"
         fi
       fi
     else # no query arugments
-      _fasd_data="$(printf %s\\n "$_fasd_data" | while read -r line; do
-        [ -${typ:-e} "${line%%\|*}" ] && printf %s\\n "$line"
-      done)"
+      local _tmp_data=$_fasd_data$'\n'; _fasd_data=""
+      while [[ "$_tmp_data" =~ ^(([^|]*)\|[^$'\n']*$'\n')(.*) ]]; do
+        [ -${typ:-e} "${BASH_REMATCH[2]}" ] && _fasd_data+=${BASH_REMATCH[1]}
+        _tmp_data=${BASH_REMATCH[3]}
+      done
+      _fasd_data=${_fasd_data%$'\n'}
     fi
 
     # query the database

--- a/fasd
+++ b/fasd
@@ -118,7 +118,7 @@ EOS
       zsh-hook) cat <<EOS
 # add zsh hook
 _fasd_preexec() {
-  { eval "fasd --proc \$(fasd --sanitize \$1)"; } >> "$_FASD_SINK" 2>&1
+  { eval "fasd --proc \$(fasd --sanitize \$2)"; } >> "$_FASD_SINK" 2>&1
 }
 autoload -Uz add-zsh-hook
 add-zsh-hook preexec _fasd_preexec
@@ -212,7 +212,7 @@ EOS
         ;;
 
       zsh-ccomp-install) cat <<EOS
-# enbale command mode completion
+# enable command mode completion
 compctl -U -K _fasd_zsh_cmd_complete -V fasd -x 'C[-1,-*e],s[-]n[1,e]' -c - \\
   'c[-1,-A][-1,-D]' -f -- fasd fasd_cd
 
@@ -502,6 +502,18 @@ $(fasd --backend $each)"
             print $1 "|" sum
           }'
         ;;
+      current)
+        for path in *; do
+          printf "$PWD/$s|1\\n" "$path"
+        done
+        ;;
+      spotlight)
+        mdfind '(kMDItemFSContentChangeDate >= $time.today) ||
+          kMDItemLastUsedDate >= $time.this_month' \
+          | sed '/Library\//d
+            /\.app$/d
+            s/$/|2/'
+        ;;
       *) eval "$2";;
     esac
     ;;
@@ -543,7 +555,7 @@ $(fasd --backend $each)"
           R*) local r=r;;
       [0-9]*) local _fasd_i="$o"; break;;
           h*) [ -z "$comp" ] && echo "fasd [options] [query ...]
-[f|a|s|d|z] [opions] [query ...]
+[f|a|s|d|z] [options] [query ...]
   options:
     -s         list paths with scores
     -l         list paths without scores

--- a/fasd
+++ b/fasd
@@ -332,13 +332,12 @@ EOS
     while [ "$1" ]; do
         [ -e "$1" ] && paths+="$1"$'\n'; shift
     done
-time {
     paths="$(sed '/^[^/]/s@^@'"$PWD"'/@
       s@/\.\.$@/../@;s@/\(\./\)\{1,\}@/@g;:0
       s@[^/][^/]*//*\.\./@/@;t 0
-      s@^/*\.\./@/@;s@//*@/@g;s@/\.\{0,1\}$@@;s@^$@/@' 2>> "$_FASD_SINK" <<< "$paths")"
+      s@^/*\.\./@/@;s@//*@/@g;s@/\.\{0,1\}$@@;s@^$@/@' \
+          2>> "$_FASD_SINK" <<< "$paths")"
     paths=${paths//$'\n'/|}
-}
 
     # add current pwd if the option is set
     [ "$_FASD_TRACK_PWD" = "1" -a "$PWD" != "$HOME" ] && paths="$paths|$PWD"
@@ -350,119 +349,119 @@ time {
     if [ ! -f $backupFile ]; then
         backupFile="$(mktemp "$_FASD_DATA".XXXXXX)" || return
     fi
-time {
     env mv -f "$_FASD_DATA" "$backupFile"
-}
 
     declare -A ranks times
-	local max="$_FASD_MAX"
+    local max="$_FASD_MAX"
     local now=$(date +%s)
     local iCount fCount
     OLDFS="$IFS"; IFS='|'
     for fname in $paths; do
-        [[ -z "$fname" ]] && continue
-        ranks[$fname]=1
-        times[$fname]=$now
+      [[ -z "$fname" ]] && continue
+      ranks[$fname]=1
+      times[$fname]=$now
     done
     IFS="$OLDFS"
 
-	declare -r scale=6
+    declare -r scale=6
     ((fCount=10**scale)); fCount=${fCount:1}  # "scale" zeros
 
     populate_ranks_and_times() {
-		# Parse the current line from the input file
-		[[ $2 =~ (.*)\|(([0-9]+)(\.([0-9]*))?)\|(.*) ]]
-		fname=${BASH_REMATCH[1]}
-		#rank=${BASH_REMATCH[2]}
-		iRank=${BASH_REMATCH[3]}
-		fRank=${BASH_REMATCH[5]}
-		time=${BASH_REMATCH[6]}
+      # Parse a line from the fasd input file
+      [[ $2 =~ (.*)\|(([0-9]+)(\.([0-9]*))?)\|(.*) ]]
+      fname=${BASH_REMATCH[1]}
+      #rank=${BASH_REMATCH[2]}
+      iRank=${BASH_REMATCH[3]}
+      fRank=${BASH_REMATCH[5]}
+      time=${BASH_REMATCH[6]}
+  
+      local d=0
+  
+      if ((iRank>=1)); then
+        if [[ -n "${ranks[${fname}]}" ]]; then
+  
+          # Compute 1/rank in several steps
 
-		local d=0
-
-        if ((iRank>=1)); then
-		  if [[ -n "${ranks[${fname}]}" ]]; then
-
-			((top = 10**${#fRank}))         # to int
-			bot=$iRank$fRank              # to int
-            # Divide top/bot with integer round:    quotient = (a/b) + (a%b > b/2)
-            ((prelim = (top*10**scale)/bot + ((top*10**scale)%bot > bot/2)))
-
-			# Prepare to shift the decimal left. If the preliminary quotient has too few
-			# digits, then left-pad it out to "scale" digits
-			((d=scale-${#prelim}))
-			if ((d>0)); then
-				prelim=$((10**d))$prelim
-				prelim=${prelim:1}
-			fi
-
-			# Break the preliminary quotient at the decimal point
-			iPart=${prelim:0:-$scale}
-			fPart=${prelim:${#prelim}-$scale}   # the last "scale" digits
-
-			# Add, compensating for precision and overflow
-            ((total_fRank=fRank*10**(scale-${#fRank})))   # rescale fRank to have "scale" digits
-			((total_iRank=iRank+iPart))
-			((total_fRank+=fPart))     # This sum might overflow, hence the following "if".
-			if ((${#total_fRank} > scale)); then
-			  total_fRank=${total_fRank:1}
-			  ((total_iRank+=1))
-			fi
-
-			# Populate the data arrays.
-			rank=$total_iRank
-			[[ -n $total_fRank ]] && rank+=.$total_fRank
-            ranks[$fname]=$rank
-            times[$fname]=$now
-
-          else
-            # Populate the data arrays.
-            rank=$iRank
-            [[ -n $fRank ]] && rank+=.$fRank
-            ranks[$fname]=$rank
-            times[$fname]=$time
+          # Convert decimals to integers
+          ((top = 10**${#fRank}))
+          bottom=$iRank$fRank
+          # Divide and round the quotient
+          ((quot = (top*10**scale)/bottom
+                 + ((top*10**scale)%bottom > bottom/2)))
+          # Left-pad the quotient with zeros
+          ((d=scale-${#quot}))
+          if ((d>0)); then
+            quot=$((10**d))$quot
+            quot=${quot:1}
           fi
-
-		  # Increase the count. Be careful about precision and overflow.
-		  ((d=scale-${#fRank}))
-		  if ((d>0)); then ((fRank*=10**d)); fi
-		  ((iCount+=iRank))
-		  ((fCount+=fRank))
-		  if ((${#fCount} > scale)); then
-			fCount=${fCount:1}
-			((iCount++))
-		  fi
-		fi
+          # Break the quotient into integer and fractional parts
+          iPart=${quot:0:-$scale}
+          fPart=${quot:${#quot}-$scale}
+ 
+          # Add rank to 1/rank
+          ((total_fRank=fPart+fRank*10**(scale-${#fRank})))   # right-pad
+          ((total_iRank=iPart+iRank))
+          if ((${#total_fRank} > scale)); then      # adjust for overflow
+            total_fRank=${total_fRank:1}
+            ((total_iRank++))
+          fi
+  
+          # Populate the data arrays
+          rank=$total_iRank
+          [[ -n $total_fRank ]] && rank+=.$total_fRank
+          ranks[$fname]=$rank
+          times[$fname]=$now
+  
+        else
+          # Populate the data arrays
+          rank=$iRank
+          [[ -n $fRank ]] && rank+=.$fRank
+          ranks[$fname]=$rank
+          times[$fname]=$time
+        fi
+  
+        # Increase the count. Be careful about precision and overflow
+        ((d=scale-${#fRank}))
+        if ((d>0)); then ((fRank*=10**d)); fi
+        ((iCount=10#$iCount+10#$iRank))   # force base-10 arithmetic
+        ((fCount=10#$fCount+10#$fRank))
+        if ((${#fCount} > scale)); then
+          fCount=${fCount:1}
+          ((iCount++))
+        fi
+      fi
     }
 
     mapfile -t -c 1 -C populate_ranks_and_times < "$backupFile"
 
-	if ((iCount > max)); then
-		for fname in "${!ranks[@]}"; do
-            [[ "${ranks[$fname]}" =~ ([0-9]*)\.([0-9]*) ]]
-            iRank=${BASH_REMATCH[1]}
-            fRank=${BASH_REMATCH[2]}
-            
-			# Multiply the rank by 0.9: first divide by 10, then multiply by 9.
-            fRank=$((iRank%10))$((fRank/10 + 2*fRank%10))  # Divide by 10 and round.
-            ((iRank/=10))
-            
-            d=${#fRank}
-            ((fRank*=9)); ((iRank*=9))
-            if ((${#fRank}>d)); then
-                ((iRank+=${fRank:0:1}))
-                fRank=${fRank:1}
-            fi
+    if ((iCount > max)); then
+      for fname in "${!ranks[@]}"; do
+        [[ "${ranks[$fname]}" =~ ([0-9]*)\.([0-9]*) ]]
+        iRank=${BASH_REMATCH[1]}
+        fRank=${BASH_REMATCH[2]}
+             
+        # Divide the rank by 10
+        fRank=$((iRank%10))$((fRank/10 + 2*fRank%10))  # Round. Grab a digit.
+        ((iRank/=10))  # Give up a digit.
+        d=${#fRank}
+        # Multiply the rank by 9
+        ((fRank*=9)); ((iRank*=9))
+        if ((${#fRank}>d)); then
+          ((iRank+=${fRank:0:1}))
+          fRank=${fRank:1}
+        fi
+ 
+        # Represent the rank as a decimal value
+        rank=$iRank; if ((fRank>0)); then rank+=.${fRank}; fi
 
-            # Represent the rank as a decimal value
-            rank=$iRank; if ((fRank>0)); then rank+=.${fRank}; fi
-
-			echo $fname"|"$rank"|"${times[$fname]} 2>> "$_FASD_SINK" >> "$_FASD_DATA"   # >| "$_FASD_DATA"
-		done
-	else
-		for fname in "${!ranks[@]}"; do
-			echo $fname"|"${ranks[$fname]}"|"${times[$fname]} 2>> "$_FASD_SINK" >> "$_FASD_DATA"   #  >| "$_FASD_DATA"
-		done
+        echo $fname"|"$rank"|"${times[$fname]} \
+            2>> "$_FASD_SINK" >> "$_FASD_DATA"   # >| "$_FASD_DATA"
+      done
+    else
+      for fname in "${!ranks[@]}"; do
+        echo $fname"|"${ranks[$fname]}"|"${times[$fname]} \
+            2>> "$_FASD_SINK" >> "$_FASD_DATA"   #  >| "$_FASD_DATA"
+      done
     fi
 
     # in case of failure, restore the backed-up file

--- a/fasd
+++ b/fasd
@@ -518,8 +518,8 @@ EOS
 
     # cat all backends
     local each _fasd_data; for each in $_FASD_BACKENDS; do
-      _fasd_data="$_fasd_data
-$(fasd --backend $each)"
+      fasd --backend $each
+      _fasd_data+=$'\n'$backendBuffer
     done
     [ "$_fasd_data" ] || _fasd_data="$(cat "$dataFile")"
 
@@ -596,37 +596,42 @@ $(fasd --backend $each)"
 
   --backend)
     case $2 in
-      native) cat "$dataFile";;
+      native)
+        backendBuffer="$(<"$dataFile")"
+        ;;
       viminfo)
-        < "$_FASD_VIMINFO" sed -n '/^>/{s@~@'"$HOME"'@
+        backendBuffer="$(sed -n '/^>/{s@~@'"$HOME"'@
           s/^..//
           p
-          }' | $_FASD_AWK -v t="$(date +%s)" '{
-            t -= 60
-            print $0 "|1|" t
-          }'
+          }' "$_FASD_VIMINFO" | $_FASD_AWK ' BEGIN {
+             t = systime() - 60 }
+            { print $0 "|1|" t
+        }')"
         ;;
       recently-used)
-        local nl="$(printf '\\\nX')"; nl="${nl%X}" # slash newline for sed
+        backendBuffer="$(
+        local nl="\\"$'\n' # slash newline for sed
         tr -d '\n' < "$_FASD_RECENTLY_USED_XBEL" | \
           sed 's@file:/@'"$nl"'@g;s@count="@'"$nl"'@g' | sed '1d;s/".*$//' | \
           tr '\n' '|' | sed 's@|/@'"$nl"'@g' | $_FASD_AWK -F'|' '{
             sum = 0
             for( i=2; i<=NF; i++ ) sum += $i
             print $1 "|" sum
-          }'
+        }')"
         ;;
       current)
+        backendBuffer=""
         for path in *; do
-          printf "$PWD/%s|1\\n" "$path"
+          backendBuffer+="$PWD/$path|1"$'\n'
         done
         ;;
       spotlight)
-        mdfind '(kMDItemFSContentChangeDate >= $time.today) ||
+          backendBuffer="$(
+          mdfind '(kMDItemFSContentChangeDate >= $time.today) ||
           kMDItemLastUsedDate >= $time.this_month' \
           | sed '/Library\//d
             /\.app$/d
-            s/$/|2/'
+            s/$/|2/')"
         ;;
       *) eval "$2";;
     esac

--- a/fasd
+++ b/fasd
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Fasd (this file) can be sourced or executed by any POSIX compatible shell.
 

--- a/fasd
+++ b/fasd
@@ -29,6 +29,9 @@
 
 fasd() {
 
+  # On Cygwin, opt for the sped-up bash version
+  [ "$OSTYPE" = cygwin ] & exec fasd.bash "@"
+
   # make zsh do word splitting inside this function
   [ "$ZSH_VERSION" ] && emulate sh && setopt localoptions
 

--- a/fasd
+++ b/fasd
@@ -115,7 +115,7 @@ EOS
       zsh-hook) cat <<EOS
 # add zsh hook
 _fasd_preexec() {
-  { eval "fasd --proc \$(fasd --sanitize \$2)"; } >> "$_FASD_SINK" 2>&1
+  { eval "fasd --proc \$(fasd --sanitize \$1)"; } >> "$_FASD_SINK" 2>&1
 }
 autoload -Uz add-zsh-hook
 add-zsh-hook preexec _fasd_preexec
@@ -210,7 +210,7 @@ EOS
         ;;
 
       zsh-ccomp-install) cat <<EOS
-# enable command mode completion
+# enbale command mode completion
 compctl -U -K _fasd_zsh_cmd_complete -V fasd -x 'C[-1,-*e],s[-]n[1,e]' -c - \\
   'c[-1,-A][-1,-D]' -f -- fasd fasd_cd
 
@@ -332,11 +332,13 @@ EOS
     while [ "$1" ]; do
         [ -e "$1" ] && paths+="$1"$'\n'; shift
     done
+time {
     paths="$(sed '/^[^/]/s@^@'"$PWD"'/@
       s@/\.\.$@/../@;s@/\(\./\)\{1,\}@/@g;:0
       s@[^/][^/]*//*\.\./@/@;t 0
       s@^/*\.\./@/@;s@//*@/@g;s@/\.\{0,1\}$@@;s@^$@/@' 2>> "$_FASD_SINK" <<< "$paths")"
     paths=${paths//$'\n'/|}
+}
 
     # add current pwd if the option is set
     [ "$_FASD_TRACK_PWD" = "1" -a "$PWD" != "$HOME" ] && paths="$paths|$PWD"
@@ -344,40 +346,125 @@ EOS
     [ -z "${paths##\|}" ] && return # stop if we have nothing to add
 
     # backup the data file and write a new file in place
-    local backupFile
-    backupFile="$_FASD_DATA".??????
-    if [ ! -e $backupFile ]; then
+    local backupFile="$_FASD_DATA".??????
+    if [ ! -f $backupFile ]; then
         backupFile="$(mktemp "$_FASD_DATA".XXXXXX)" || return
     fi
+time {
     env mv -f "$_FASD_DATA" "$backupFile"
-    $_FASD_AWK -v list="$paths" -v max="$_FASD_MAX" -F"|" '
-      BEGIN {
-        now = systime()
-        split(list, files, "|")
-        for(i in files) {
-          path = files[i]
-          if(path == "") continue
-          paths[path] = path # array for checking
-          rank[path] = 1
-          time[path] = now
-        }
-      }
-      $2 >= 1 {
-        if($1 in paths) {
-          rank[$1] = $2 + 1 / $2
-          time[$1] = now
-        } else {
-          rank[$1] = $2
-          time[$1] = $3
-        }
-        count += $2
-      }
-      END {
-        if(count > max)
-          for(i in rank) print i "|" 0.9*rank[i] "|" time[i] # aging
-        else
-          for(i in rank) print i "|" rank[i] "|" time[i]
-      }' "$backupFile" 2>> "$_FASD_SINK" >| "$_FASD_DATA"
+}
+
+    declare -A ranks times
+	local max="$_FASD_MAX"
+    local now=$(date +%s)
+    local iCount fCount
+    OLDFS="$IFS"; IFS='|'
+    for fname in $paths; do
+        [[ -z "$fname" ]] && continue
+        ranks[$fname]=1
+        times[$fname]=$now
+    done
+    IFS="$OLDFS"
+
+	declare -r scale=6
+    ((fCount=10**scale)); fCount=${fCount:1}  # "scale" zeros
+
+    populate_ranks_and_times() {
+		# Parse the current line from the input file
+		[[ $2 =~ (.*)\|(([0-9]+)(\.([0-9]*))?)\|(.*) ]]
+		fname=${BASH_REMATCH[1]}
+		#rank=${BASH_REMATCH[2]}
+		iRank=${BASH_REMATCH[3]}
+		fRank=${BASH_REMATCH[5]}
+		time=${BASH_REMATCH[6]}
+
+		local d=0
+
+        if ((iRank>=1)); then
+		  if [[ -n "${ranks[${fname}]}" ]]; then
+
+			((top = 10**${#fRank}))         # to int
+			bot=$iRank$fRank              # to int
+            # Divide top/bot with integer round:    quotient = (a/b) + (a%b > b/2)
+            ((prelim = (top*10**scale)/bot + ((top*10**scale)%bot > bot/2)))
+
+			# Prepare to shift the decimal left. If the preliminary quotient has too few
+			# digits, then left-pad it out to "scale" digits
+			((d=scale-${#prelim}))
+			if ((d>0)); then
+				prelim=$((10**d))$prelim
+				prelim=${prelim:1}
+			fi
+
+			# Break the preliminary quotient at the decimal point
+			iPart=${prelim:0:-$scale}
+			fPart=${prelim:${#prelim}-$scale}   # the last "scale" digits
+
+			# Add, compensating for precision and overflow
+            ((total_fRank=fRank*10**(scale-${#fRank})))   # rescale fRank to have "scale" digits
+			((total_iRank=iRank+iPart))
+			((total_fRank+=fPart))     # This sum might overflow, hence the following "if".
+			if ((${#total_fRank} > scale)); then
+			  total_fRank=${total_fRank:1}
+			  ((total_iRank+=1))
+			fi
+
+			# Populate the data arrays.
+			rank=$total_iRank
+			[[ -n $total_fRank ]] && rank+=.$total_fRank
+            ranks[$fname]=$rank
+            times[$fname]=$now
+
+          else
+            # Populate the data arrays.
+            rank=$iRank
+            [[ -n $fRank ]] && rank+=.$fRank
+            ranks[$fname]=$rank
+            times[$fname]=$time
+          fi
+
+		  # Increase the count. Be careful about precision and overflow.
+		  ((d=scale-${#fRank}))
+		  if ((d>0)); then ((fRank*=10**d)); fi
+		  ((iCount+=iRank))
+		  ((fCount+=fRank))
+		  if ((${#fCount} > scale)); then
+			fCount=${fCount:1}
+			((iCount++))
+		  fi
+		fi
+    }
+
+    mapfile -t -c 1 -C populate_ranks_and_times < "$backupFile"
+
+	if ((iCount > max)); then
+		for fname in "${!ranks[@]}"; do
+            [[ "${ranks[$fname]}" =~ ([0-9]*)\.([0-9]*) ]]
+            iRank=${BASH_REMATCH[1]}
+            fRank=${BASH_REMATCH[2]}
+            
+			# Multiply the rank by 0.9: first divide by 10, then multiply by 9.
+            fRank=$((iRank%10))$((fRank/10 + 2*fRank%10))  # Divide by 10 and round.
+            ((iRank/=10))
+            
+            d=${#fRank}
+            ((fRank*=9)); ((iRank*=9))
+            if ((${#fRank}>d)); then
+                ((iRank+=${fRank:0:1}))
+                fRank=${fRank:1}
+            fi
+
+            # Represent the rank as a decimal value
+            rank=$iRank; if ((fRank>0)); then rank+=.${fRank}; fi
+
+			echo $fname"|"$rank"|"${times[$fname]} 2>> "$_FASD_SINK" >> "$_FASD_DATA"   # >| "$_FASD_DATA"
+		done
+	else
+		for fname in "${!ranks[@]}"; do
+			echo $fname"|"${ranks[$fname]}"|"${times[$fname]} 2>> "$_FASD_SINK" >> "$_FASD_DATA"   #  >| "$_FASD_DATA"
+		done
+    fi
+
     # in case of failure, restore the backed-up file
     if [ $? -ne 0 -a -f "$backupFile" ]; then
       env mv -f "$backupFile" "$_FASD_DATA"
@@ -512,18 +599,6 @@ $(fasd --backend $each)"
             print $1 "|" sum
           }'
         ;;
-      current)
-        for path in *; do
-          printf "$PWD/%s|1\\n" "$path"
-        done
-        ;;
-      spotlight)
-        mdfind '(kMDItemFSContentChangeDate >= $time.today) ||
-          kMDItemLastUsedDate >= $time.this_month' \
-          | sed '/Library\//d
-            /\.app$/d
-            s/$/|2/'
-        ;;
       *) eval "$2";;
     esac
     ;;
@@ -565,7 +640,7 @@ $(fasd --backend $each)"
           R*) local r=r;;
       [0-9]*) local _fasd_i="$o"; break;;
           h*) [ -z "$comp" ] && echo "fasd [options] [query ...]
-[f|a|s|d|z] [options] [query ...]
+[f|a|s|d|z] [opions] [query ...]
   options:
     -s         list paths with scores
     -l         list paths without scores

--- a/fasd
+++ b/fasd
@@ -131,7 +131,7 @@ EOS
       zsh-hook) cat <<EOS
 # add zsh hook
 _fasd_preexec() {
-  { eval "fasd --proc \$(fasd --sanitize \$2)"; } >> "$_FASD_SINK" 2>&1
+  { eval "fasd --proc \$2"; } >> "$_FASD_SINK" 2>&1
 }
 autoload -Uz add-zsh-hook
 add-zsh-hook preexec _fasd_preexec
@@ -142,7 +142,7 @@ EOS
 _fasd_prompt_func() {
     local cmd=\$(history 1)
     [[ "\$cmd" =~ ^[\ ]*[0-9]*[\ ]*(.*) ]] && cmd=\${BASH_REMATCH[1]}
-  eval "fasd --proc \$(fasd --sanitize \$cmd)" >> "$_FASD_SINK" 2>&1
+    eval "fasd --proc \$cmd" >> "$_FASD_SINK" 2>&1
 }
 # add bash hook
 case \$PROMPT_COMMAND in
@@ -154,7 +154,7 @@ EOS
 
       posix-hook) cat <<EOS
 _fasd_ps1_func() {
-  { eval "fasd --proc \$(fasd --sanitize \$(fc -nl -1))"; } \\
+  { eval "fasd --proc \$(fc -nl -1)"; } \\
     >> "$_FASD_SINK" 2>&1
 }
 case \$PS1 in
@@ -165,9 +165,8 @@ EOS
         ;;
 
       tcsh-hook) cat <<EOS
-;alias fasd-prev-cmd 'fasd --sanitize \`history -h 1\`';
 set pprecmd="\`alias precmd\`";
-alias precmd '\$pprecmd; eval "fasd --proc \`fasd-prev-cmd\`" >& /dev/null';
+alias precmd '\$pprecmd; eval "fasd --proc \`history -h 1\`" >& /dev/null';
 EOS
 
         ;;
@@ -292,18 +291,16 @@ EOS
     esac
     ;;
 
-  # sanitize: it seems this is meant to remove most shell operators,
-  # leaving only word-like arguments
-  --sanitize) shift; local y="$*"$'\n'
-      if [[ "$y" =~ [^\][|\&\;\<\>$\`{}$'\n'] ]]; then
-          sed 's/\([^\]\)$( *[^ ]* *\([^)]*\)))*/\1\2/g
-               s/\([^\]\)[|&;<>$`{}]\{1,\}/\1 /g' <<< "$y"
-      else echo "$y"
-      fi
-    ;;
-
   --proc) shift # process commands
-    # stop if we don't own the current data file or $_FASD_RO is set
+
+    # "sanitize" the command, removing shell operators and metacharacters
+    local y="$*"$'\n'
+    while [[ "$y" =~ (.*[^\])[|\&\;\<\>$\`{}]+(.*) ]]; do
+      y=${BASH_REMATCH[1]}${BASH_REMATCH[2]}
+    done
+    eval set "-- "$y
+
+    # stop if we don't own $dataFile or $_FASD_RO is set
     [ -f "$dataFile" -a ! -O "$dataFile" ] || [ "$_FASD_RO" ] && return
 
     # blacklists

--- a/fasd
+++ b/fasd
@@ -405,7 +405,7 @@ EOS
           fPart=${quot:${#quot}-$scale}
  
           # Add rank to 1/rank
-          ((total_fRank=fPart+fRank*10**(scale-${#fRank})))   # right-pad
+          ((total_fRank=10#$fPart+(10#$fRank)*10**(scale-${#fRank})))   # right-pad
           ((total_iRank=iPart+iRank))
           if ((${#total_fRank} > scale)); then      # adjust for overflow
             total_fRank=${total_fRank:1}
@@ -428,7 +428,7 @@ EOS
   
         # Increase the count. Be careful about precision and overflow
         ((d=scale-${#fRank}))
-        if ((d>0)); then ((fRank*=10**d)); fi
+        if ((d>0)); then ((fRank=(10#$fRank)*10**d)); fi
         ((iCount=10#$iCount+10#$iRank))   # force base-10 arithmetic
         ((fCount=10#$fCount+10#$fRank))
         if ((${#fCount} > scale)); then

--- a/fasd
+++ b/fasd
@@ -61,6 +61,24 @@ fasd() {
               $awk "" && _FASD_AWK=$awk && break
             done
           fi
+
+          # set up a rotating pair of _FASD_DATA files as an alternative
+          # to issuing mktemp/mv/rm/cp commands in various places
+          if [ -f $_FASD_DATA.1 -a -f $_FASD_DATA.2 ]; then
+            if [ $_FASD_DATA.1 -nt $_FASD_DATA.2 ]; then
+              dataFile=$_FASD_DATA.1
+              newDataFile=$_FASD_DATA.2
+            else
+              dataFile=$_FASD_DATA.2
+              newDataFile=$_FASD_DATA.1
+            fi
+          elif [ -f $_FASD_DATA.1 ]; then
+            dataFile=$_FASD_DATA.1
+            newDataFile=$_FASD_DATA.2
+          else   # look for an unpaired data file; we will pair it up
+            dataFile=$_FASD_DATA
+            newDataFile=$_FASD_DATA.1
+          fi
         } >> "${_FASD_SINK:-/dev/null}" 2>&1
         ;;
 
@@ -285,8 +303,8 @@ EOS
     ;;
 
   --proc) shift # process commands
-    # stop if we don't own $_FASD_DATA or $_FASD_RO is set
-    [ -f "$_FASD_DATA" -a ! -O "$_FASD_DATA" ] || [ "$_FASD_RO" ] && return
+    # stop if we don't own the current data file or $_FASD_RO is set
+    [ -f "$dataFile" -a ! -O "$dataFile" ] || [ "$_FASD_RO" ] && return
 
     # blacklists
     local each; for each in $_FASD_BLACKLIST; do
@@ -310,8 +328,8 @@ EOS
     ;;
 
   --add|-A) shift # add entries
-    # stop if we don't own $_FASD_DATA or $_FASD_RO is set
-    [ -f "$_FASD_DATA" -a ! -O "$_FASD_DATA" ] || [ "$_FASD_RO" ] && return
+    # stop if we don't own the current data file or $_FASD_RO is set
+    [ -f "$dataFile" -a ! -O "$dataFile" ] || [ "$_FASD_RO" ] && return
 
     # find all valid path arguments, convert them to simplest absolute form
     local paths=""
@@ -340,13 +358,7 @@ EOS
 
     [ -z "${paths##\|}" ] && return # stop if we have nothing to add
 
-    # backup the data file and write a new file in place
-    local backupFile="$_FASD_DATA".??????
-    if [ ! -f $backupFile ]; then
-        backupFile="$(mktemp "$_FASD_DATA".XXXXXX)" || return
-    fi
-    env mv -f "$_FASD_DATA" "$backupFile"
-
+    # prepare to calculate the new fasd data from the current data
     declare -A ranks times
     local max="$_FASD_MAX"
     local now=$(date +%s)
@@ -362,8 +374,9 @@ EOS
     declare -r scale=6
     ((fCount=10**scale)); fCount=${fCount:1}  # "scale" zeros
 
+    # calculation function that acts on every line of the data file
     populate_ranks_and_times() {
-      # Parse a line from the fasd input file
+      # Parse a line of fasd data
       [[ $2 =~ (.*)\|(([0-9]+)(\.([0-9]*))?)\|(.*) ]]
       fname=${BASH_REMATCH[1]}
       #rank=${BASH_REMATCH[2]}
@@ -428,8 +441,9 @@ EOS
       fi
     }
 
-    mapfile -t -c 1 -C populate_ranks_and_times < "$backupFile"
+    mapfile -t -c 1 -C populate_ranks_and_times < "$dataFile"
 
+    # Shrink the rankings if they exceed the threshold. Write the new file. 
     if ((iCount > max)); then
       for fname in "${!ranks[@]}"; do
         [[ "${ranks[$fname]}" =~ ([0-9]*)\.([0-9]*) ]]
@@ -450,26 +464,39 @@ EOS
         # Represent the rank as a decimal value
         rank=$iRank; if ((fRank>0)); then rank+=.${fRank}; fi
 
-        echo $fname"|"$rank"|"${times[$fname]} \
-            2>> "$_FASD_SINK" >> "$_FASD_DATA"   # >| "$_FASD_DATA"
+        # append to or write the new file as appropriate
+        if ((written>0)); then
+          echo $fname"|"$rank"|"${times[$fname]} \
+            2>> "$_FASD_SINK" >> "$newDataFile"
+        else
+          echo $fname"|"$rank"|"${times[$fname]} \
+            2>> "$_FASD_SINK" >| "$newDataFile"
+          written=1
+        fi
       done
     else
       for fname in "${!ranks[@]}"; do
-        echo $fname"|"${ranks[$fname]}"|"${times[$fname]} \
-            2>> "$_FASD_SINK" >> "$_FASD_DATA"   #  >| "$_FASD_DATA"
+        if ((written>0)); then
+          echo $fname"|"${ranks[$fname]}"|"${times[$fname]} \
+            2>> "$_FASD_SINK" >> "$newDataFile"
+        else
+          echo $fname"|"${ranks[$fname]}"|"${times[$fname]} \
+            2>> "$_FASD_SINK" >| "$newDataFile"
+          written=1
+        fi
       done
     fi
 
-    # in case of failure, restore the backed-up file
-    if [ $? -ne 0 -a -f "$backupFile" ]; then
-      env mv -f "$backupFile" "$_FASD_DATA"
-      touch "$backupFile"
+    # in case of failure, fall back on the preexisting data
+    # TODO: replace $? with a cumulative error counter
+    if [ $? -ne 0 -a -f "$dataFile" ]; then
+      touch "$dataFile"    # make this file "newer" for next time
     fi
     ;;
 
   --delete|-D) shift # delete entries
-    # stop if we don't own $_FASD_DATA or $_FASD_RO is set
-    [ -f "$_FASD_DATA" -a ! -O "$_FASD_DATA" ] || [ "$_FASD_RO" ] && return
+    # stop if we don't own the current data file or $_FASD_RO is set
+    [ -f "$dataFile" -a ! -O "$dataFile" ] || [ "$_FASD_RO" ] && return
 
     # turn valid arguments into entry-deleting sed commands
     local sed_cmd="$(while [ "$1" ]; do printf %s\\n "$1"; shift; done | \
@@ -478,21 +505,16 @@ EOS
         s@^/*\.\./@/@;s@//*@/@g;s@/\.\{0,1\}$@@
         s@^$@/@;s@\([.[\/*^$]\)@\\\1@g;s@^\(.*\)$@/^\1|/d@' 2>> "$_FASD_SINK")"
 
-    # maintain the file
-    local tempfile
-    tempfile="$(mktemp "$_FASD_DATA".XXXXXX)" || return
+    sed "$sed_cmd" "$dataFile" 2>> "$_FASD_SINK" >| "$newDataFile"
 
-    sed "$sed_cmd" "$_FASD_DATA" 2>> "$_FASD_SINK" >| "$tempfile"
-
-    if [ $? -ne 0 -a -f "$_FASD_DATA" ]; then
-      env rm -f "$tempfile"
-    else
-      env mv -f "$tempfile" "$_FASD_DATA"
+    # in case of failure, fall back on the preexisting data
+    if [ $? -ne 0 -a -f "$dataFile" ]; then
+      touch "$dataFile"
     fi
     ;;
 
   --query) shift # query the db, --query [$typ ["$fnd" [$mode]]]
-    [ -f "$_FASD_DATA" ] || return # no db yet
+    [ -f "$dataFile" ] || return # no db yet
     [ "$1" ] && local typ="$1"
     [ "$2" ] && local fnd="$2"
     [ "$3" ] && local mode="$3"
@@ -502,7 +524,7 @@ EOS
       _fasd_data="$_fasd_data
 $(fasd --backend $each)"
     done
-    [ "$_fasd_data" ] || _fasd_data="$(cat "$_FASD_DATA")"
+    [ "$_fasd_data" ] || _fasd_data="$(cat "$dataFile")"
 
     # set mode specific code for calculating the prior
     case $mode in
@@ -574,7 +596,7 @@ $(fasd --backend $each)"
 
   --backend)
     case $2 in
-      native) cat "$_FASD_DATA";;
+      native) cat "$dataFile";;
       viminfo)
         < "$_FASD_VIMINFO" sed -n '/^>/{s@~@'"$HOME"'@
           s/^..//
@@ -690,7 +712,7 @@ fasd [-A|-D] [paths ...]
     elif [ "$interactive" ] || [ "$exec" -a -z "$fnd$lst$show" -a -t 1 ]; then
       if [ "$(printf %s "$res" | sed -n '$=')" -gt 1 ]; then
         res="$(printf %s\\n "$res" | sort -n${R})"
-        printf %s\\n "$res" | sed = | sed 'N;s/\n/  /' | sort -nr >&2
+        printf %s\\n "$res" | sed = | sed 'N;s/\n/	/' | sort -nr >&2
         printf "> " >&2
         local i; read i; [ 0 -lt "${i:-0}" ] 2>> "$_FASD_SINK" || return 1
       fi

--- a/fasd
+++ b/fasd
@@ -74,7 +74,6 @@ fasd() {
     eval "\$(fasd --init posix-alias posix-hook)"
   fi
 } >> "$_FASD_SINK" 2>&1
-
 EOS
         ;;
 
@@ -97,7 +96,6 @@ fasd_cd() {
 }
 alias z='fasd_cd -d'
 alias zz='fasd_cd -d -i'
-
 EOS
         ;;
 
@@ -115,11 +113,10 @@ EOS
       zsh-hook) cat <<EOS
 # add zsh hook
 _fasd_preexec() {
-  { eval "fasd --proc \$(fasd --sanitize \$1)"; } >> "$_FASD_SINK" 2>&1
+  { eval "fasd --proc \$(fasd --sanitize \$2)"; } >> "$_FASD_SINK" 2>&1
 }
 autoload -Uz add-zsh-hook
 add-zsh-hook preexec _fasd_preexec
-
 EOS
         ;;
 
@@ -129,13 +126,11 @@ _fasd_prompt_func() {
     [[ "\$cmd" =~ ^[\ ]*[0-9]*[\ ]*(.*) ]] && cmd=\${BASH_REMATCH[1]}
   eval "fasd --proc \$(fasd --sanitize \$cmd)" >> "$_FASD_SINK" 2>&1
 }
-
 # add bash hook
 case \$PROMPT_COMMAND in
   *_fasd_prompt_func*) ;;
   *) PROMPT_COMMAND="_fasd_prompt_func;\$PROMPT_COMMAND";;
 esac
-
 EOS
         ;;
 
@@ -148,7 +143,6 @@ case \$PS1 in
   *_fasd_ps1_func*) ;;
   *) export PS1="\\\$(_fasd_ps1_func)\$PS1";;
 esac
-
 EOS
         ;;
 
@@ -168,7 +162,6 @@ _fasd_zsh_cmd_complete() {
   (( \$+compstate )) && compstate[insert]=menu # no expand if compsys loaded
   reply=(\${(f)"\$(fasd --complete "\$compl")"})
 }
-
 EOS
         ;;
 
@@ -196,24 +189,20 @@ EOS
   zle -C fasd-complete complete-word _generic
   zstyle ':completion:fasd-complete:*' completer _fasd_zsh_word_complete
   zstyle ':completion:fasd-complete:*' menu-select
-
   zle -C fasd-complete-f complete-word _generic
   zstyle ':completion:fasd-complete-f:*' completer _fasd_zsh_word_complete_f
   zstyle ':completion:fasd-complete-f:*' menu-select
-
   zle -C fasd-complete-d complete-word _generic
   zstyle ':completion:fasd-complete-d:*' completer _fasd_zsh_word_complete_d
   zstyle ':completion:fasd-complete-d:*' menu-select
 }
-
 EOS
         ;;
 
       zsh-ccomp-install) cat <<EOS
-# enbale command mode completion
+# enable command mode completion
 compctl -U -K _fasd_zsh_cmd_complete -V fasd -x 'C[-1,-*e],s[-]n[1,e]' -c - \\
   'c[-1,-A][-1,-D]' -f -- fasd fasd_cd
-
 EOS
         ;;
 
@@ -231,7 +220,6 @@ EOS
   fi
   unset orig_comp
 }
-
 EOS
         ;;
 
@@ -261,14 +249,12 @@ _fasd_bash_hook_cmd_complete() {
     complete -F _fasd_bash_cmd_complete \$cmd
   done
 }
-
 EOS
         ;;
 
       bash-ccomp-install) cat <<EOS
 # enable bash command mode completion
 _fasd_bash_hook_cmd_complete fasd a s d f sd sf z zz
-
 EOS
         ;;
       esac; shift
@@ -608,6 +594,18 @@ $(fasd --backend $each)"
             print $1 "|" sum
           }'
         ;;
+      current)
+        for path in *; do
+          printf "$PWD/%s|1\\n" "$path"
+        done
+        ;;
+      spotlight)
+        mdfind '(kMDItemFSContentChangeDate >= $time.today) ||
+          kMDItemLastUsedDate >= $time.this_month' \
+          | sed '/Library\//d
+            /\.app$/d
+            s/$/|2/'
+        ;;
       *) eval "$2";;
     esac
     ;;
@@ -649,7 +647,7 @@ $(fasd --backend $each)"
           R*) local r=r;;
       [0-9]*) local _fasd_i="$o"; break;;
           h*) [ -z "$comp" ] && echo "fasd [options] [query ...]
-[f|a|s|d|z] [opions] [query ...]
+[f|a|s|d|z] [options] [query ...]
   options:
     -s         list paths with scores
     -l         list paths without scores
@@ -665,7 +663,6 @@ $(fasd --backend $each)"
     -R         reverse listing order
     -h         show a brief help message
     -[0-9]     select the nth entry
-
 fasd [-A|-D] [paths ...]
     -A    add paths
     -D    delete paths" >&2 && return;;
@@ -693,7 +690,7 @@ fasd [-A|-D] [paths ...]
     elif [ "$interactive" ] || [ "$exec" -a -z "$fnd$lst$show" -a -t 1 ]; then
       if [ "$(printf %s "$res" | sed -n '$=')" -gt 1 ]; then
         res="$(printf %s\\n "$res" | sort -n${R})"
-        printf %s\\n "$res" | sed = | sed 'N;s/\n/	/' | sort -nr >&2
+        printf %s\\n "$res" | sed = | sed 'N;s/\n/  /' | sort -nr >&2
         printf "> " >&2
         local i; read i; [ 0 -lt "${i:-0}" ] 2>> "$_FASD_SINK" || return 1
       fi
@@ -730,4 +727,3 @@ case $- in
       fasd "$@"
     fi;;
 esac
-

--- a/fasd
+++ b/fasd
@@ -504,7 +504,7 @@ $(fasd --backend $each)"
         ;;
       current)
         for path in *; do
-          printf "$PWD/$s|1\\n" "$path"
+          printf "$PWD/%s|1\\n" "$path"
         done
         ;;
       spotlight)

--- a/fasd
+++ b/fasd
@@ -125,8 +125,9 @@ EOS
 
       bash-hook) cat <<EOS
 _fasd_prompt_func() {
-  eval "fasd --proc \$(fasd --sanitize \$(history 1 | \\
-    sed "s/^[ ]*[0-9]*[ ]*//"))" >> "$_FASD_SINK" 2>&1
+    local cmd=\$(history 1)
+    [[ "\$cmd" =~ ^[\ ]*[0-9]*[\ ]*(.*) ]] && cmd=\${BASH_REMATCH[1]}
+  eval "fasd --proc \$(fasd --sanitize \$cmd)" >> "$_FASD_SINK" 2>&1
 }
 
 # add bash hook
@@ -287,9 +288,14 @@ EOS
     esac
     ;;
 
-  --sanitize) shift; printf %s\\n "$*" | \
-      sed 's/\([^\]\)$( *[^ ]* *\([^)]*\)))*/\1\2/g
-        s/\([^\]\)[|&;<>$`{}]\{1,\}/\1 /g'
+  # sanitize: it seems this is meant to remove most shell operators,
+  # leaving only word-like arguments
+  --sanitize) shift; local y="$*"$'\n'
+      if [[ "$y" =~ [^\][|\&\;\<\>$\`{}$'\n'] ]]; then
+          sed 's/\([^\]\)$( *[^ ]* *\([^)]*\)))*/\1\2/g
+               s/\([^\]\)[|&;<>$`{}]\{1,\}/\1 /g' <<< "$y"
+      else echo "$y"
+      fi
     ;;
 
   --proc) shift # process commands
@@ -322,24 +328,31 @@ EOS
     [ -f "$_FASD_DATA" -a ! -O "$_FASD_DATA" ] || [ "$_FASD_RO" ] && return
 
     # find all valid path arguments, convert them to simplest absolute form
-    local paths="$(while [ "$1" ]; do
-      [ -e "$1" ] && printf %s\\n "$1"; shift
-    done | sed '/^[^/]/s@^@'"$PWD"'/@
+    local paths=""
+    while [ "$1" ]; do
+        [ -e "$1" ] && paths+="$1"$'\n'; shift
+    done
+    paths="$(sed '/^[^/]/s@^@'"$PWD"'/@
       s@/\.\.$@/../@;s@/\(\./\)\{1,\}@/@g;:0
       s@[^/][^/]*//*\.\./@/@;t 0
-      s@^/*\.\./@/@;s@//*@/@g;s@/\.\{0,1\}$@@;s@^$@/@' 2>> "$_FASD_SINK" \
-      | tr '\n' '|')"
+      s@^/*\.\./@/@;s@//*@/@g;s@/\.\{0,1\}$@@;s@^$@/@' 2>> "$_FASD_SINK" <<< "$paths")"
+    paths=${paths//$'\n'/|}
 
     # add current pwd if the option is set
     [ "$_FASD_TRACK_PWD" = "1" -a "$PWD" != "$HOME" ] && paths="$paths|$PWD"
 
     [ -z "${paths##\|}" ] && return # stop if we have nothing to add
 
-    # maintain the file
-    local tempfile
-    tempfile="$(mktemp "$_FASD_DATA".XXXXXX)" || return
-    $_FASD_AWK -v list="$paths" -v now="$(date +%s)" -v max="$_FASD_MAX" -F"|" '
+    # backup the data file and write a new file in place
+    local backupFile
+    backupFile="$_FASD_DATA".??????
+    if [ ! -e $backupFile ]; then
+        backupFile="$(mktemp "$_FASD_DATA".XXXXXX)" || return
+    fi
+    env mv -f "$_FASD_DATA" "$backupFile"
+    $_FASD_AWK -v list="$paths" -v max="$_FASD_MAX" -F"|" '
       BEGIN {
+        now = systime()
         split(list, files, "|")
         for(i in files) {
           path = files[i]
@@ -364,11 +377,11 @@ EOS
           for(i in rank) print i "|" 0.9*rank[i] "|" time[i] # aging
         else
           for(i in rank) print i "|" rank[i] "|" time[i]
-      }' "$_FASD_DATA" 2>> "$_FASD_SINK" >| "$tempfile"
-    if [ $? -ne 0 -a -f "$_FASD_DATA" ]; then
-      env rm -f "$tempfile"
-    else
-      env mv -f "$tempfile" "$_FASD_DATA"
+      }' "$backupFile" 2>> "$_FASD_SINK" >| "$_FASD_DATA"
+    # in case of failure, restore the backed-up file
+    if [ $? -ne 0 -a -f "$backupFile" ]; then
+      env mv -f "$backupFile" "$_FASD_DATA"
+      touch "$backupFile"
     fi
     ;;
 

--- a/fasd
+++ b/fasd
@@ -62,8 +62,8 @@ fasd() {
             done
           fi
 
-          # set up a rotating pair of _FASD_DATA files as an alternative
-          # to issuing mktemp/mv/rm/cp commands in various places
+          # set up a rotating pair of _FASD_DATA files
+          # so we can avoid issuing mktemp/mv/rm/cp commands
           if [ -f $_FASD_DATA.1 -a -f $_FASD_DATA.2 ]; then
             if [ $_FASD_DATA.1 -nt $_FASD_DATA.2 ]; then
               dataFile=$_FASD_DATA.1
@@ -631,12 +631,14 @@ $(fasd --backend $each)"
 
   *) # parsing logic and processing
     local fnd= last= _FASD_BACKENDS="$_FASD_BACKENDS" _fasd_data= comp= exec=
-    while [ "$1" ]; do case $1 in
+    while [ "$1" ]; do
+      case $1 in
       --complete) [ "$2" = "--" ] && shift; set -- $2; local lst=1 r=r comp=1;;
       --query|--add|--delete|-A|-D) fasd "$@"; return $?;;
       --version) [ -z "$comp" ] && echo "1.0.1" && return;;
       --) while [ "$2" ]; do shift; fnd="$fnd $1"; last="$1"; done;;
-      -*) local o="${1#-}"; while [ "$o" ]; do case $o in
+      -*) local o="${1#-}"; while [ "$o" ]; do 
+          case $o in
           s*) local show=1;;
           l*) local lst=1;;
           i*) [ -z "$comp" ] && local interactive=1 show=1;;
@@ -682,6 +684,7 @@ $(fasd --backend $each)"
     -R         reverse listing order
     -h         show a brief help message
     -[0-9]     select the nth entry
+
 fasd [-A|-D] [paths ...]
     -A    add paths
     -D    delete paths" >&2 && return;;
@@ -746,3 +749,4 @@ case $- in
       fasd "$@"
     fi;;
 esac
+

--- a/fasd.bash
+++ b/fasd.bash
@@ -7,6 +7,7 @@
 # been rewritten.
 
 # Copyright (C) 2011, 2012 by Wei Dai. All rights reserved.
+# Copyright (C) 2016 by Michael Wood. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/fasd.bash
+++ b/fasd.bash
@@ -487,6 +487,8 @@ EOS
       done
     fi
 
+    unset ranks times
+
     # in case of failure, fall back on the preexisting data
     # TODO: replace $? with a cumulative error counter
     if [ $? -ne 0 -a -f "$dataFile" ]; then
@@ -666,6 +668,7 @@ EOS
       ;;
     esac
       
+      unset ranks times
     ;;
 
   --backend)

--- a/fasd.bash
+++ b/fasd.bash
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Fasd (this file) can be sourced or executed by any POSIX compatible shell.
 
@@ -61,6 +61,24 @@ fasd() {
               $awk "" && _FASD_AWK=$awk && break
             done
           fi
+
+          # set up a rotating pair of _FASD_DATA files
+          # so we can avoid issuing mktemp/mv/rm/cp commands
+          if [ -f $_FASD_DATA.1 -a -f $_FASD_DATA.2 ]; then
+            if [ $_FASD_DATA.1 -nt $_FASD_DATA.2 ]; then
+              dataFile=$_FASD_DATA.1
+              newDataFile=$_FASD_DATA.2
+            else
+              dataFile=$_FASD_DATA.2
+              newDataFile=$_FASD_DATA.1
+            fi
+          elif [ -f $_FASD_DATA.1 ]; then
+            dataFile=$_FASD_DATA.1
+            newDataFile=$_FASD_DATA.2
+          else   # look for an unpaired data file; we will pair it up
+            dataFile=$_FASD_DATA
+            newDataFile=$_FASD_DATA.1
+          fi
         } >> "${_FASD_SINK:-/dev/null}" 2>&1
         ;;
 
@@ -74,7 +92,6 @@ fasd() {
     eval "\$(fasd --init posix-alias posix-hook)"
   fi
 } >> "$_FASD_SINK" 2>&1
-
 EOS
         ;;
 
@@ -97,7 +114,6 @@ fasd_cd() {
 }
 alias z='fasd_cd -d'
 alias zz='fasd_cd -d -i'
-
 EOS
         ;;
 
@@ -115,46 +131,42 @@ EOS
       zsh-hook) cat <<EOS
 # add zsh hook
 _fasd_preexec() {
-  { eval "fasd --proc \$(fasd --sanitize \$1)"; } >> "$_FASD_SINK" 2>&1
+  { eval "fasd --proc \$2"; } >> "$_FASD_SINK" 2>&1
 }
 autoload -Uz add-zsh-hook
 add-zsh-hook preexec _fasd_preexec
-
 EOS
         ;;
 
       bash-hook) cat <<EOS
 _fasd_prompt_func() {
-  eval "fasd --proc \$(fasd --sanitize \$(history 1 | \\
-    sed "s/^[ ]*[0-9]*[ ]*//"))" >> "$_FASD_SINK" 2>&1
+    local cmd=\$(history 1)
+    [[ "\$cmd" =~ ^[\ ]*[0-9]*[\ ]*(.*) ]] && cmd=\${BASH_REMATCH[1]}
+    eval "fasd --proc \$cmd" >> "$_FASD_SINK" 2>&1
 }
-
 # add bash hook
 case \$PROMPT_COMMAND in
   *_fasd_prompt_func*) ;;
   *) PROMPT_COMMAND="_fasd_prompt_func;\$PROMPT_COMMAND";;
 esac
-
 EOS
         ;;
 
       posix-hook) cat <<EOS
 _fasd_ps1_func() {
-  { eval "fasd --proc \$(fasd --sanitize \$(fc -nl -1))"; } \\
+  { eval "fasd --proc \$(fc -nl -1)"; } \\
     >> "$_FASD_SINK" 2>&1
 }
 case \$PS1 in
   *_fasd_ps1_func*) ;;
   *) export PS1="\\\$(_fasd_ps1_func)\$PS1";;
 esac
-
 EOS
         ;;
 
       tcsh-hook) cat <<EOS
-;alias fasd-prev-cmd 'fasd --sanitize \`history -h 1\`';
 set pprecmd="\`alias precmd\`";
-alias precmd '\$pprecmd; eval "fasd --proc \`fasd-prev-cmd\`" >& /dev/null';
+alias precmd '\$pprecmd; eval "fasd --proc \`history -h 1\`" >& /dev/null';
 EOS
 
         ;;
@@ -167,7 +179,6 @@ _fasd_zsh_cmd_complete() {
   (( \$+compstate )) && compstate[insert]=menu # no expand if compsys loaded
   reply=(\${(f)"\$(fasd --complete "\$compl")"})
 }
-
 EOS
         ;;
 
@@ -195,24 +206,20 @@ EOS
   zle -C fasd-complete complete-word _generic
   zstyle ':completion:fasd-complete:*' completer _fasd_zsh_word_complete
   zstyle ':completion:fasd-complete:*' menu-select
-
   zle -C fasd-complete-f complete-word _generic
   zstyle ':completion:fasd-complete-f:*' completer _fasd_zsh_word_complete_f
   zstyle ':completion:fasd-complete-f:*' menu-select
-
   zle -C fasd-complete-d complete-word _generic
   zstyle ':completion:fasd-complete-d:*' completer _fasd_zsh_word_complete_d
   zstyle ':completion:fasd-complete-d:*' menu-select
 }
-
 EOS
         ;;
 
       zsh-ccomp-install) cat <<EOS
-# enbale command mode completion
+# enable command mode completion
 compctl -U -K _fasd_zsh_cmd_complete -V fasd -x 'C[-1,-*e],s[-]n[1,e]' -c - \\
   'c[-1,-A][-1,-D]' -f -- fasd fasd_cd
-
 EOS
         ;;
 
@@ -230,7 +237,6 @@ EOS
   fi
   unset orig_comp
 }
-
 EOS
         ;;
 
@@ -260,14 +266,12 @@ _fasd_bash_hook_cmd_complete() {
     complete -F _fasd_bash_cmd_complete \$cmd
   done
 }
-
 EOS
         ;;
 
       bash-ccomp-install) cat <<EOS
 # enable bash command mode completion
 _fasd_bash_hook_cmd_complete fasd a s d f sd sf z zz
-
 EOS
         ;;
       esac; shift
@@ -287,14 +291,17 @@ EOS
     esac
     ;;
 
-  --sanitize) shift; printf %s\\n "$*" | \
-      sed 's/\([^\]\)$( *[^ ]* *\([^)]*\)))*/\1\2/g
-        s/\([^\]\)[|&;<>$`{}]\{1,\}/\1 /g'
-    ;;
-
   --proc) shift # process commands
-    # stop if we don't own $_FASD_DATA or $_FASD_RO is set
-    [ -f "$_FASD_DATA" -a ! -O "$_FASD_DATA" ] || [ "$_FASD_RO" ] && return
+
+    # "sanitize" the command, removing shell operators and metacharacters
+    local y="$*"$'\n'
+    while [[ "$y" =~ (.*[^\])[|\&\;\<\>$\`{}]+(.*) ]]; do
+      y=${BASH_REMATCH[1]}${BASH_REMATCH[2]}
+    done
+    eval set "-- "$y
+
+    # stop if we don't own $dataFile or $_FASD_RO is set
+    [ -f "$dataFile" -a ! -O "$dataFile" ] || [ "$_FASD_RO" ] && return
 
     # blacklists
     local each; for each in $_FASD_BLACKLIST; do
@@ -318,63 +325,175 @@ EOS
     ;;
 
   --add|-A) shift # add entries
-    # stop if we don't own $_FASD_DATA or $_FASD_RO is set
-    [ -f "$_FASD_DATA" -a ! -O "$_FASD_DATA" ] || [ "$_FASD_RO" ] && return
+    # stop if we don't own the current data file or $_FASD_RO is set
+    [ -f "$dataFile" -a ! -O "$dataFile" ] || [ "$_FASD_RO" ] && return
 
     # find all valid path arguments, convert them to simplest absolute form
-    local paths="$(while [ "$1" ]; do
-      [ -e "$1" ] && printf %s\\n "$1"; shift
-    done | sed '/^[^/]/s@^@'"$PWD"'/@
-      s@/\.\.$@/../@;s@/\(\./\)\{1,\}@/@g;:0
-      s@[^/][^/]*//*\.\./@/@;t 0
-      s@^/*\.\./@/@;s@//*@/@g;s@/\.\{0,1\}$@@;s@^$@/@' 2>> "$_FASD_SINK" \
-      | tr '\n' '|')"
+    local paths=""
+    while [ "$1" ]; do
+      [ ! -e "$1" ] && { shift; continue; }
+      p=$1
+      [[ "$p" =~ ^/ ]] || p="$PWD"/$p                  # make paths absolute
+      while [[ "$p" =~ (.*)/\./(.*) ]]; do             # clean up "./"
+        p=${BASH_REMATCH[1]}/${BASH_REMATCH[2]}
+      done
+      [[ "$p" =~ /\.\.$ ]] && p+=/                     # clean up final ".."
+      while [[ "$p" =~ (.*)[^/]+[/]+\.\./(.*) ]]; do   # clean up "../"
+        p=${BASH_REMATCH[1]}/${BASH_REMATCH[2]}
+      done
+      [[ "$p" =~ ^[/]?\.\.(/.*) ]] && p=${BASH_REMATCH[1]} # clean initial /../
+      while [[ "$p" =~ (.*)//(.*) ]]; do               # delete redundant /s
+        p=${BASH_REMATCH[1]}/${BASH_REMATCH[2]}
+      done
+      [[ "$p" =~ (.*)/[.]?$ ]] && p=${BASH_REMATCH[1]} # delete final / or /.
+      paths+=$p"|"
+      shift
+    done
 
     # add current pwd if the option is set
     [ "$_FASD_TRACK_PWD" = "1" -a "$PWD" != "$HOME" ] && paths="$paths|$PWD"
 
     [ -z "${paths##\|}" ] && return # stop if we have nothing to add
 
-    # maintain the file
-    local tempfile
-    tempfile="$(mktemp "$_FASD_DATA".XXXXXX)" || return
-    $_FASD_AWK -v list="$paths" -v now="$(date +%s)" -v max="$_FASD_MAX" -F"|" '
-      BEGIN {
-        split(list, files, "|")
-        for(i in files) {
-          path = files[i]
-          if(path == "") continue
-          paths[path] = path # array for checking
-          rank[path] = 1
-          time[path] = now
-        }
-      }
-      $2 >= 1 {
-        if($1 in paths) {
-          rank[$1] = $2 + 1 / $2
-          time[$1] = now
-        } else {
-          rank[$1] = $2
-          time[$1] = $3
-        }
-        count += $2
-      }
-      END {
-        if(count > max)
-          for(i in rank) print i "|" 0.9*rank[i] "|" time[i] # aging
+    # prepare to calculate the new fasd data from the current data
+    declare -A ranks times
+    local max="$_FASD_MAX"
+    local now=$(date +%s)
+    local iCount fCount
+    OLDFS="$IFS"; IFS='|'
+    for fname in $paths; do
+      [[ -z "$fname" ]] && continue
+      ranks[$fname]=1
+      times[$fname]=$now
+    done
+    IFS="$OLDFS"
+
+    declare -r scale=6
+    ((fCount=10**scale)); fCount=${fCount:1}  # "scale" zeros
+
+    # calculation function that acts on every line of the data file
+    populate_ranks_and_times() {
+      # Parse a line of fasd data
+      [[ $2 =~ (.*)\|(([0-9]+)(\.([0-9]*))?)\|(.*) ]]
+      fname=${BASH_REMATCH[1]}
+      #rank=${BASH_REMATCH[2]}
+      iRank=${BASH_REMATCH[3]}
+      fRank=${BASH_REMATCH[5]}
+      time=${BASH_REMATCH[6]}
+  
+      local d=0
+  
+      if ((iRank>=1)); then
+        if [[ -n "${ranks[${fname}]}" ]]; then
+  
+          # Compute 1/rank in several steps
+
+          # Convert decimals to integers
+          ((top = 10**${#fRank}))
+          bottom=$iRank$fRank
+          # Divide and round the quotient
+          ((quot = (top*10**scale)/bottom
+                 + ((top*10**scale)%bottom > bottom/2)))
+          # Left-pad the quotient with zeros
+          ((d=scale-${#quot}))
+          if ((d>0)); then
+            quot=$((10**d))$quot
+            quot=${quot:1}
+          fi
+          # Break the quotient into integer and fractional parts
+          iPart=${quot:0:-$scale}
+          fPart=${quot:${#quot}-$scale}
+ 
+          # Add rank to 1/rank
+          ((total_fRank=10#$fPart+(10#$fRank)*10**(scale-${#fRank})))   # right-pad
+          ((total_iRank=iPart+iRank))
+          if ((${#total_fRank} > scale)); then      # adjust for overflow
+            total_fRank=${total_fRank:1}
+            ((total_iRank++))
+          fi
+  
+          # Populate the data arrays
+          rank=$total_iRank
+          [[ -n $total_fRank ]] && rank+=.$total_fRank
+          ranks[$fname]=$rank
+          times[$fname]=$now
+  
         else
-          for(i in rank) print i "|" rank[i] "|" time[i]
-      }' "$_FASD_DATA" 2>> "$_FASD_SINK" >| "$tempfile"
-    if [ $? -ne 0 -a -f "$_FASD_DATA" ]; then
-      env rm -f "$tempfile"
+          # Populate the data arrays
+          rank=$iRank
+          [[ -n $fRank ]] && rank+=.$fRank
+          ranks[$fname]=$rank
+          times[$fname]=$time
+        fi
+  
+        # Increase the count. Be careful about precision and overflow
+        ((d=scale-${#fRank}))
+        if ((d>0)); then ((fRank=(10#$fRank)*10**d)); fi
+        ((iCount=10#$iCount+10#$iRank))   # force base-10 arithmetic
+        ((fCount=10#$fCount+10#$fRank))
+        if ((${#fCount} > scale)); then
+          fCount=${fCount:1}
+          ((iCount++))
+        fi
+      fi
+    }
+
+    mapfile -t -c 1 -C populate_ranks_and_times < "$dataFile"
+
+    # Shrink the rankings if they exceed the threshold. Write the new file. 
+    if ((iCount > max)); then
+      for fname in "${!ranks[@]}"; do
+        [[ "${ranks[$fname]}" =~ ([0-9]*)\.([0-9]*) ]]
+        iRank=${BASH_REMATCH[1]}
+        fRank=${BASH_REMATCH[2]}
+             
+        # Divide the rank by 10
+        fRank=$((iRank%10))$((fRank/10 + 2*fRank%10))  # Round. Grab a digit.
+        ((iRank/=10))  # Give up a digit.
+        d=${#fRank}
+        # Multiply the rank by 9
+        ((fRank*=9)); ((iRank*=9))
+        if ((${#fRank}>d)); then
+          ((iRank+=${fRank:0:1}))
+          fRank=${fRank:1}
+        fi
+ 
+        # Represent the rank as a decimal value
+        rank=$iRank; if ((fRank>0)); then rank+=.${fRank}; fi
+
+        # append to or write the new file as appropriate
+        if ((written>0)); then
+          echo $fname"|"$rank"|"${times[$fname]} \
+            2>> "$_FASD_SINK" >> "$newDataFile"
+        else
+          echo $fname"|"$rank"|"${times[$fname]} \
+            2>> "$_FASD_SINK" >| "$newDataFile"
+          written=1
+        fi
+      done
     else
-      env mv -f "$tempfile" "$_FASD_DATA"
+      for fname in "${!ranks[@]}"; do
+        if ((written>0)); then
+          echo $fname"|"${ranks[$fname]}"|"${times[$fname]} \
+            2>> "$_FASD_SINK" >> "$newDataFile"
+        else
+          echo $fname"|"${ranks[$fname]}"|"${times[$fname]} \
+            2>> "$_FASD_SINK" >| "$newDataFile"
+          written=1
+        fi
+      done
+    fi
+
+    # in case of failure, fall back on the preexisting data
+    # TODO: replace $? with a cumulative error counter
+    if [ $? -ne 0 -a -f "$dataFile" ]; then
+      touch "$dataFile"    # make this file "newer" for next time
     fi
     ;;
 
   --delete|-D) shift # delete entries
-    # stop if we don't own $_FASD_DATA or $_FASD_RO is set
-    [ -f "$_FASD_DATA" -a ! -O "$_FASD_DATA" ] || [ "$_FASD_RO" ] && return
+    # stop if we don't own the current data file or $_FASD_RO is set
+    [ -f "$dataFile" -a ! -O "$dataFile" ] || [ "$_FASD_RO" ] && return
 
     # turn valid arguments into entry-deleting sed commands
     local sed_cmd="$(while [ "$1" ]; do printf %s\\n "$1"; shift; done | \
@@ -383,31 +502,26 @@ EOS
         s@^/*\.\./@/@;s@//*@/@g;s@/\.\{0,1\}$@@
         s@^$@/@;s@\([.[\/*^$]\)@\\\1@g;s@^\(.*\)$@/^\1|/d@' 2>> "$_FASD_SINK")"
 
-    # maintain the file
-    local tempfile
-    tempfile="$(mktemp "$_FASD_DATA".XXXXXX)" || return
+    sed "$sed_cmd" "$dataFile" 2>> "$_FASD_SINK" >| "$newDataFile"
 
-    sed "$sed_cmd" "$_FASD_DATA" 2>> "$_FASD_SINK" >| "$tempfile"
-
-    if [ $? -ne 0 -a -f "$_FASD_DATA" ]; then
-      env rm -f "$tempfile"
-    else
-      env mv -f "$tempfile" "$_FASD_DATA"
+    # in case of failure, fall back on the preexisting data
+    if [ $? -ne 0 -a -f "$dataFile" ]; then
+      touch "$dataFile"
     fi
     ;;
 
   --query) shift # query the db, --query [$typ ["$fnd" [$mode]]]
-    [ -f "$_FASD_DATA" ] || return # no db yet
+    [ -f "$dataFile" ] || return # no db yet
     [ "$1" ] && local typ="$1"
     [ "$2" ] && local fnd="$2"
     [ "$3" ] && local mode="$3"
 
     # cat all backends
     local each _fasd_data; for each in $_FASD_BACKENDS; do
-      _fasd_data="$_fasd_data
-$(fasd --backend $each)"
+      fasd --backend $each
+      _fasd_data+=$'\n'$backendBuffer
     done
-    [ "$_fasd_data" ] || _fasd_data="$(cat "$_FASD_DATA")"
+    [ "$_fasd_data" ] || _fasd_data="$(cat "$dataFile")"
 
     # set mode specific code for calculating the prior
     case $mode in
@@ -447,9 +561,12 @@ $(fasd --backend $each)"
         fi
       fi
     else # no query arugments
-      _fasd_data="$(printf %s\\n "$_fasd_data" | while read -r line; do
-        [ -${typ:-e} "${line%%\|*}" ] && printf %s\\n "$line"
-      done)"
+      local _tmp_data=$_fasd_data$'\n'; _fasd_data=""
+      while [[ "$_tmp_data" =~ ^(([^|]*)\|[^$'\n']*$'\n')(.*) ]]; do
+        [ -${typ:-e} "${BASH_REMATCH[2]}" ] && _fasd_data+=${BASH_REMATCH[1]}
+        _tmp_data=${BASH_REMATCH[3]}
+      done
+      _fasd_data=${_fasd_data%$'\n'}
     fi
 
     # query the database
@@ -479,25 +596,42 @@ $(fasd --backend $each)"
 
   --backend)
     case $2 in
-      native) cat "$_FASD_DATA";;
+      native)
+        backendBuffer="$(<"$dataFile")"
+        ;;
       viminfo)
-        < "$_FASD_VIMINFO" sed -n '/^>/{s@~@'"$HOME"'@
+        backendBuffer="$(sed -n '/^>/{s@~@'"$HOME"'@
           s/^..//
           p
-          }' | $_FASD_AWK -v t="$(date +%s)" '{
-            t -= 60
-            print $0 "|1|" t
-          }'
+          }' "$_FASD_VIMINFO" | $_FASD_AWK ' BEGIN {
+             t = systime() - 60 }
+            { print $0 "|1|" t
+        }')"
         ;;
       recently-used)
-        local nl="$(printf '\\\nX')"; nl="${nl%X}" # slash newline for sed
+        backendBuffer="$(
+        local nl="\\"$'\n' # slash newline for sed
         tr -d '\n' < "$_FASD_RECENTLY_USED_XBEL" | \
           sed 's@file:/@'"$nl"'@g;s@count="@'"$nl"'@g' | sed '1d;s/".*$//' | \
           tr '\n' '|' | sed 's@|/@'"$nl"'@g' | $_FASD_AWK -F'|' '{
             sum = 0
             for( i=2; i<=NF; i++ ) sum += $i
             print $1 "|" sum
-          }'
+        }')"
+        ;;
+      current)
+        backendBuffer=""
+        for path in *; do
+          backendBuffer+="$PWD/$path|1"$'\n'
+        done
+        ;;
+      spotlight)
+          backendBuffer="$(
+          mdfind '(kMDItemFSContentChangeDate >= $time.today) ||
+          kMDItemLastUsedDate >= $time.this_month' \
+          | sed '/Library\//d
+            /\.app$/d
+            s/$/|2/')"
         ;;
       *) eval "$2";;
     esac
@@ -505,12 +639,14 @@ $(fasd --backend $each)"
 
   *) # parsing logic and processing
     local fnd= last= _FASD_BACKENDS="$_FASD_BACKENDS" _fasd_data= comp= exec=
-    while [ "$1" ]; do case $1 in
+    while [ "$1" ]; do
+      case $1 in
       --complete) [ "$2" = "--" ] && shift; set -- $2; local lst=1 r=r comp=1;;
       --query|--add|--delete|-A|-D) fasd "$@"; return $?;;
       --version) [ -z "$comp" ] && echo "1.0.1" && return;;
       --) while [ "$2" ]; do shift; fnd="$fnd $1"; last="$1"; done;;
-      -*) local o="${1#-}"; while [ "$o" ]; do case $o in
+      -*) local o="${1#-}"; while [ "$o" ]; do 
+          case $o in
           s*) local show=1;;
           l*) local lst=1;;
           i*) [ -z "$comp" ] && local interactive=1 show=1;;
@@ -540,7 +676,7 @@ $(fasd --backend $each)"
           R*) local r=r;;
       [0-9]*) local _fasd_i="$o"; break;;
           h*) [ -z "$comp" ] && echo "fasd [options] [query ...]
-[f|a|s|d|z] [opions] [query ...]
+[f|a|s|d|z] [options] [query ...]
   options:
     -s         list paths with scores
     -l         list paths without scores

--- a/fasd.bash
+++ b/fasd.bash
@@ -33,6 +33,8 @@ fasd() {
   # make zsh do word splitting inside this function
   [ "$ZSH_VERSION" ] && emulate sh && setopt localoptions
 
+  shopt -s extglob
+
   case $1 in
   --init) shift
     while [ "$1" ]; do
@@ -460,7 +462,7 @@ EOS
         fi
  
         # Represent the rank as a decimal value
-        rank=$iRank; if ((fRank>0)); then rank+=.${fRank}; fi
+        rank=$iRank; if ((fRank>0)); then rank+=.${fRank%%+(0)}; fi
 
         # append to or write the new file as appropriate
         if ((written>0)); then
@@ -656,7 +658,7 @@ EOS
           fi
 
           ranks[$path]=$iRk
-          if ((fRk>0)); then ranks[$path]+="."$fRk; fi
+          if ((fRk>0)); then ranks[$path]+="."${fRk%%+(0)}; fi
           printf "%-10s %s\n" ${ranks[$path]} $path
         done
       ;;

--- a/fasd.bash
+++ b/fasd.bash
@@ -522,7 +522,8 @@ EOS
     # cat all backends
     local each _fasd_data; for each in $_FASD_BACKENDS; do
       fasd --backend $each
-      _fasd_data+=$'\n'$backendBuffer
+      [[ -n $_fasd_data ]] && _fasd_data+=$'\n'
+      _fasd_data+=$backendBuffer
     done
     [ "$_fasd_data" ] || _fasd_data="$(cat "$dataFile")"
 
@@ -629,6 +630,7 @@ EOS
         for path in "${!times[@]}"; do
           input+=${times[$path]}" "$path$'\n'
         done
+        input=${input%$'\n'}
         $_FASD_AWK -v t=$t '
         {
           prior=sqrt(100000/(1+t-$1))


### PR DESCRIPTION
Hello,

I've implemented a series of speedups to **fasd** running on Cygwin; please refer to issue #39. 

Some of my changes involve bashisms, so I've split off my work into a new script, **fasd.bash** which is _exec_'ed by the original **fasd** _in Cygwin environments only_ and ignored otherwise. Of course other techniques for addressing compatibility are possible.

So far, I've addressed the command-line hook and the aliases "f", "a" and "d". Since these changes are working nicely for me and the project has been relatively inactive for some time, I thought I'd stop for the time being and solicit some feedback. Thanks for your attention.
