### PR TITLE
Do not "eval" in zsh's _fasd_preexec

### DIFF
--- a/fasd
+++ b/fasd
@@ -115,7 +115,7 @@ EOS
       zsh-hook) cat <<EOS
 # add zsh hook
 _fasd_preexec() {
-  { eval "fasd --proc \$(fasd --sanitize \$2)"; } >> "$_FASD_SINK" 2>&1
+  { fasd --proc \$(fasd --sanitize "\$2") } >> "$_FASD_SINK" 2>&1
 }
 autoload -Uz add-zsh-hook
 add-zsh-hook preexec _fasd_preexec


### PR DESCRIPTION
This causes the following to misbehave:

```
% foo=0
% $((foo++))
zsh: command not found: 1
% echo $foo
2
```

While it should be:

```
% foo=0
% $((foo++))
zsh: command not found: 0
% echo $foo
1
```

This should probably also not be used with the other shells, but I have
not investigated there.
