### PR TITLE
Adds option _FASD_NOCASE to force default matching to ignore case

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,8 @@ $_FASD_RECENTLY_USED_XBEL
 Path to XDG recently-used.xbel file for recently-used backend, defaults to
 "$HOME/.local/share/recently-used.xbel"
 
+$_FASD_NOCASE
+Force case insensitivity for default matching with value 1, defaults to 0.
 ```
 
 # Debugging

--- a/fasd
+++ b/fasd
@@ -54,6 +54,7 @@ fasd() {
           [ -z "$_FASD_VIMINFO" ] && _FASD_VIMINFO="$HOME/.viminfo"
           [ -z "$_FASD_RECENTLY_USED_XBEL" ] && \
             _FASD_RECENTLY_USED_XBEL="$HOME/.local/share/recently-used.xbel"
+          [ -z "$_FASD_NOCASE" ] && _FASD_NOCASE=0
 
           if [ -z "$_FASD_AWK" ]; then
             # awk preferences
@@ -420,13 +421,15 @@ $(fasd --backend $each)"
       local bre="$(printf %s\\n "$fnd" | sed 's/\([*\.\\\[]\)/\\\1/g
         s@ @[^|]*@g;s/\$$/|/')"
       bre='^[^|]*'"$bre"'[^|/]*|'
-      local _ret="$(printf %s\\n "$_fasd_data" | grep -i "$bre")"
+      local _ret="$(printf %s\\n "$_fasd_data" | grep "$bre")"
+      # force no case matching
+      [ "$_FASD_NOCASE" = 1 ] && _ret="$(printf %s\\n "$_fasd_data" | grep -i "$bre")"
       [ "$_ret" ] && _ret="$(printf %s\\n "$_ret" | while read -r line; do
         [ -${typ:-e} "${line%%\|*}" ] && printf %s\\n "$line"
       done)"
       if [ "$_ret" ]; then
         _fasd_data="$_ret"
-      else # no case mathcing
+      else # no case matching
         _ret="$(printf %s\\n "$_fasd_data" | grep -i "$bre")"
         [ "$_ret" ] && _ret="$(printf %s\\n "$_ret" | while read -r line; do
           [ -${typ:-e} "${line%%\|*}" ] && printf %s\\n "$line"

--- a/fasd
+++ b/fasd
@@ -422,7 +422,7 @@ $(fasd --backend $each)"
         s@ @[^|]*@g;s/\$$/|/')"
       bre='^[^|]*'"$bre"'[^|/]*|'
       local _ret="$(printf %s\\n "$_fasd_data" | grep "$bre")"
-      # force no case matching
+      # force no case matching for default matching
       [ "$_FASD_NOCASE" = 1 ] && _ret="$(printf %s\\n "$_fasd_data" | grep -i "$bre")"
       [ "$_ret" ] && _ret="$(printf %s\\n "$_ret" | while read -r line; do
         [ -${typ:-e} "${line%%\|*}" ] && printf %s\\n "$line"

--- a/fasd
+++ b/fasd
@@ -416,11 +416,11 @@ $(fasd --backend $each)"
       *) local prior='times[i] * frecent(la[i])';;
     esac
 
-    if [ "$fnd" ]; then # dafault matching
+    if [ "$fnd" ]; then # default matching
       local bre="$(printf %s\\n "$fnd" | sed 's/\([*\.\\\[]\)/\\\1/g
         s@ @[^|]*@g;s/\$$/|/')"
       bre='^[^|]*'"$bre"'[^|/]*|'
-      local _ret="$(printf %s\\n "$_fasd_data" | grep "$bre")"
+      local _ret="$(printf %s\\n "$_fasd_data" | grep -i "$bre")"
       [ "$_ret" ] && _ret="$(printf %s\\n "$_ret" | while read -r line; do
         [ -${typ:-e} "${line%%\|*}" ] && printf %s\\n "$line"
       done)"

--- a/fasd.1
+++ b/fasd.1
@@ -285,6 +285,9 @@ Path\ to\ .viminfo\ file\ for\ viminfo\ backend,\ defaults\ to\ "$HOME/.viminfo"
 $_FASD_RECENTLY_USED_XBEL
 Path\ to\ XDG\ recently\-used.xbel\ file\ for\ recently\-used\ backend,\ defaults\ to
 "$HOME/.local/share/recently\-used.xbel"
+
+$_FASD_NOCASE
+Force\ case\ insensitivity\ for\ default\ matching\ with\ value\ 1,\ defaults\ to \0.
 \f[]
 .fi
 .SH DEBUGGING

--- a/fasd.1.md
+++ b/fasd.1.md
@@ -243,6 +243,10 @@ they are present. Below are some variables you can set:
     Path to XDG recently-used.xbel file for recently-used backend, defaults to
     "$HOME/.local/share/recently-used.xbel"
 
+    $_FASD_NOCASE
+    Force case insensitivity for default matching with value 1, defaults to 0.
+
+
 # DEBUGGING
 
 Fasd is hosted on GitHub: https://github.com/clvv/fasd


### PR DESCRIPTION
This option allows the user to force fasd to ignore case when performing default matching. This overrides the default behavior, where a case-sensitive match takes priority over other capitalizations.