### PR TITLE
Stop leakage of cmd variable into bash shell

### DIFF
--- a/fasd
+++ b/fasd
@@ -256,6 +256,7 @@ _fasd_bash_cmd_complete() {
   local IFS=\$'\\n'; COMPREPLY=( \$RESULT )
 }
 _fasd_bash_hook_cmd_complete() {
+  local cmd
   for cmd in \$*; do
     complete -F _fasd_bash_cmd_complete \$cmd
   done


### PR DESCRIPTION
Without this change, fasd creates a bash hook that leaks the `cmd` variable. You can see this by entering `echo "$cmd"` into a bash shell that has sourced fasd.