### PR TITLE
Add snapcraft.yaml to build and publish it on https://snapcraft.io/store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+#snapcraft specifics
+/parts/
+/stage/
+/prime/
+
+*.snap
+
+.snapcraft
+__pycache__
+*.pyc
+*_source.tar.bz2
+snap/.snapcraft

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: fasd # you probably want to 'snapcraft register <name>'
+base: core18 # the base snap is the execution environment for this snap
+version: '1.0.1' # just for humans, typically '1.2+git' or '1.3.2'
+license: MIT
+summary: Commnd-line productivity booster. # 79 char long summary
+description: |
+  Fasd (pronounced similar to "fast") is a command-line productivity booster. 
+  Fasd offers quick access to files and directories for POSIX shells. It is 
+  inspired by tools like autojump, z and v. Fasd keeps track of files and 
+  directories you have accessed, so that you can quickly reference them in the 
+  command line. The name fasd comes from the default suggested aliases f(files),
+  a(files/directories), s(show/search/select), d(directories).
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict # use 'strict' once you have the right plugs and slots
+
+apps:
+  fasd:
+    command: usr/local/bin/fasd
+parts:
+  fasd:
+    plugin: make
+    source: https://github.com/clvv/fasd.git
+    source-tag: '1.0.1'


### PR DESCRIPTION
Currently different linux based distro uses the different package manager. Snapcraft has brought the abstraction over it. I found it very suitable while playing with multiple linux distro. So, this is small addition to this from me.

Now, it is available on [snapcraft store](https://snapcraft.io/fasd) under beta channel. Though it is published under my name. I'm fine with moving it under snapcrafter or @clvv for maintaining it.

Signed-off-by: Swapnil Mhamane <swapnilgmhamane@gmail.com>