### PR TITLE
Amended fasd_cd to output pwd following z, zz, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,11 @@ disable fuzzy matching. Default value is 2.
 $_FASD_VIMINFO
 Path to .viminfo file for viminfo backend, defaults to "$HOME/.viminfo"
 
+$_FASD_PWD
+Set to "1" will print the pwd to the terminal after a successful cd using z 
+or fasd_cd etc. Useful if your PS1 does not show the entire folder path.
+Not set, or set to any other value, will not print anything.
+
 $_FASD_RECENTLY_USED_XBEL
 Path to XDG recently-used.xbel file for recently-used backend, defaults to
 "$HOME/.local/share/recently-used.xbel"

--- a/fasd
+++ b/fasd
@@ -92,7 +92,10 @@ fasd_cd() {
   else
     local _fasd_ret="\$(fasd -e 'printf %s' "\$@")"
     [ -z "\$_fasd_ret" ] && return
-    [ -d "\$_fasd_ret" ] && cd "\$_fasd_ret" || printf %s\\n "\$_fasd_ret"
+    [ -d "\$_fasd_ret" ] && {
+        cd "\$_fasd_ret"
+        [ "\$_FASD_PWD" == "1" ] && pwd AA true
+    } || printf %s\\n "\$_fasd_ret"
   fi
 }
 alias z='fasd_cd -d'


### PR DESCRIPTION
The pwd command is conditional on "$_FASD_PWD" == "1"; default action
if it is not set or set to anything else is not to output pwd.

I got this from the 'z' project (which I otherwise did not get on
with). It is useful for people with a $PS1 that does not show the
/entire/very/long/folder/path, like me with a not-so-wide terminal.

I also edited the README.md to include info on the env var.

This is my first PR, so if it’s out of order or not acceptable, please
let me know and I shan’t do it again!